### PR TITLE
Disable marketplace integrations and outline Kunstort roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,55 @@
-<div align="center">
-	<a href="https://www.qloapps.com"><img src="https://forums.qloapps.com/assets/uploads/system/site-logo.png?v=hkl8e1230fo" alt="QloApps"></a>
-	<br>
-	<p>
-		<b>QloApps - An open source and free platform to launch your own hotel booking website</b>
-	</p>
-</div>
+# Kunstort Lehnin Hotel Management (QloApps Fork)
 
-<p align="center">
-	<a href="https://qloapps.com/download/"><img src="https://img.shields.io/badge/Download-Download%20QloApps%20-brightgreen" alt="Download"></a>
-	<a href="https://docs.qloapps.com/"><img src="https://img.shields.io/badge/Documentation-Blog-yellowgreen" alt="Documentation"></a>
-	<a href="https://forums.qloapps.com/"><img src="https://img.shields.io/badge/Forum-Help%2FSupport-green" alt="Forum"></a>
-	<a href="https://qloapps.com/addons/"><img src="https://img.shields.io/badge/Addons-Plugins-blueviolet" alt="Addons"></a>
-	<a href="https://qloapps.com/contact/"><img src="https://img.shields.io/badge/Contact-Get%20In%20Touch-blue" alt="Contact us"></a>
-	<a href="/LICENSE.md"><img src="https://img.shields.io/badge/License-OSL%20V3-green" alt="License"></a>
-</p>
+## Overview
+This repository is a lean fork of QloApps that is being transformed into a residency- and hotel-management tool for [Kunstort Lehnin](https://kunstortlehnin.de). The objective is to keep the reliable billing and room data models from QloApps while removing all marketplace cruft and re-centering the product on an HS/3-style booking calendar and enquiry-driven workflows.
 
-## Topics
-- [Topics](#topics)
-	- [Introduction](#introduction)
-	- [Requirements](#requirements)
-		- [Hosted Server Configurations](#hosted-server-configurations)
-		- [Local Server Configurations](#local-server-configurations)
-	- [Installation and Configuration](#installation-and-configuration)
-	- [License](#license)
-	- [Security Vulnerabilities](#security-vulnerabilities)
-	- [Documentation & Demo](#documentation--demo)
-		- [QloApps Documentation](#qloapps-documentation)
-		- [QloApps Demo](#qloapps-demo)
-	- [Contribute](#contribute)
-	- [Credits](#credits)
+Key characteristics of the fork:
+- 🚫 **Marketplace free** – outbound calls to the QloApps / Prestashop module stores are disabled by default.
+- 🧩 **Extensible from source** – custom modules can still be developed and dropped into `modules/` without depending on proprietary services.
+- 📆 **Calendar first** – upcoming development focuses on a resource timeline covering rooms, ateliers, seminar rooms and programme spaces.
+- 📨 **Inquiry workflow** – the shopping-cart driven booking journey will be replaced with curated requests that staff confirm manually.
 
+The high-level concept and roadmap live in [`concept.md`](concept.md). Tactical progress is tracked in [`checklist.md`](checklist.md).
 
-### Introduction
+## Requirements
+The project still runs on the QloApps/PrestaShop stack. For development you will need:
 
-QloApps is one kind of a true open-source hotel reservation system and a booking engine. The system is dedicated to channeling the power of the open-source community to serve the hospitality industry.
+- PHP 8.1 – 8.4 with extensions: PDO_MySQL, cURL, OpenSSL, SOAP, GD, SimpleXML, DOM, Zip, Phar.
+- MySQL/MariaDB 5.7 – 8.4.
+- Apache or Nginx with HTTPS support.
+- Composer (for dependency management) and npm/yarn if you plan to rebuild assets.
 
-From small independent hotels to big hotel chains, QloApps is a one-stop solution for all your hotel business needs.
+Increase PHP limits for development (memory ≥ 256M, max_execution_time ≥ 300) to accommodate module installations and asset builds.
 
-You will be able to launch your hotel website, showcase your property and take and manage bookings.
+## Getting Started
+1. Clone the repository and install dependencies:
+   ```bash
+   composer install
+   ```
+2. Create a database and copy `config/settings.inc.php` from the installer or your previous QloApps installation.
+3. Make sure `config/defines_custom.inc.php` is loaded (it is included automatically) so that marketplace integrations remain disabled.
+4. Run the classic QloApps installer by visiting `/install` in your browser, or migrate an existing database.
 
-### Requirements
+After installation you can log into the admin back office at `/admin` (rename the directory for security). The module catalogue will no longer attempt to connect to external stores; only locally available modules are listed.
 
-In order to install QloApps you will need the following server configurations for hosted and local serves.
-The system compatibility will also be checked by the system with installation and if the server is not compatible then the installation will not move ahead.
+## Distribution Flags
+All Kunstort-specific flags live in `config/defines_custom.inc.php`:
 
-#### Hosted Server Configurations
+- `_QLOAPP_DISABLE_MARKETPLACE_` – when `true`, disables outbound marketplace requests and UI components.
+- `_KUNSTORT_CORE_MODE_` – describes the current interaction model (`'inquiry'` while we move away from carts).
 
-* **Web server**: Apache 1.3, Apache 2.x, Nginx or Microsoft IIS
-* **PHP  version**: PHP 8.1+ to PHP 8.4
-* **MySQL version**:  5.7+ to 8.4 installed with a database created
-* SSH or FTP access (ask your hosting service for your credentials)
-* In the PHP configuration ask your provider to set memory_limit to "128M", upload_max_filesize to "16M" ,    max_execution_time to "500" and allow_url_fopen "on"
-* SSL certificate if you plan to process payments internally (not using PayPal for instance)
-* **Required PHP extensions**: PDO_MySQL, cURL, OpenSSL, SOAP, GD, SimpleXML, DOM, Zip, Phar
+Use these constants in future contributions to gate legacy commerce flows.
 
-#### Local Server Configurations
+## Development Priorities
+- Transform the admin booking calendar into a per-resource timeline with drag-and-drop management.
+- Introduce a unified resource taxonomy (rooms, ateliers, gastronomy) in the database and admin forms.
+- Replace the front-office room list with storytelling-driven templates and an enquiry form.
+- Provide CSV/ICS exports to support residency and seminar scheduling outside the app.
 
-* **Supported operating system**: Windows, Mac, and Linux
-* **A prepared package**: WampServer (for Windows), Xampp (for Windows and Mac) or EasyPHP (for Windows)
-* **Web server**: Apache 1.3, Apache 2.x, Nginx or Microsoft IIS
-* **PHP**: PHP 8.1+ to PHP 8.4
-* **MySQL** 5.7+ to 8.4 installed with a database created
-* In the PHP configuration, set memory_limit to "128M", upload_max_filesize to "16M" and max_execution_time to "500"
-* **Required PHP extensions**: PDO_MySQL, cURL, OpenSSL, SOAP, GD, SimpleXML, DOM, Zip, Phar
+See [`checklist.md`](checklist.md) for the current implementation status.
 
-### Installation and Configuration
+## Contributing
+This fork welcomes contributions that reinforce the above goals. Keep the codebase libre and avoid reintroducing external marketplaces or proprietary dependencies. Please open issues or discussions before large structural changes.
 
-**1.** You can install QloApps easily after downloading QloApps. There are easy steps for the installation process. Please visit [QloApps Installation Guide](https://qloapps.com/install-qloapps/) and follow the steps for the successful installation.
-
-**2.** Or you can install QloApps with docker image. For the docker image of QloApps, please visit [Dockerize image of QloApps](https://hub.docker.com/r/webkul/qloapps_docker) <br>
-* Docker pull command
-~~~
-docker pull webkul/qloapps_docker
-~~~
-
-### License
-
-QloApps Core is licensed under OSL-3.0 and Modules authored by Webkul have their applicable license, LICENSE.md, kept inside their root directories, while other modules are licensed under AFL-3.0.
-
-The online copy of OSL-3.0 can be found at [https://opensource.org/licenses/OSL-3.0](https://opensource.org/licenses/OSL-3.0).
-
-The online copy of AFL-3.0 can be found at [https://opensource.org/licenses/AFL-3.0](https://opensource.org/licenses/AFL-3.0).
-
-### Security Vulnerabilities
-
-Please don't disclose security vulnerabilities publicly. If you find any security vulnerability in QloApps then please email us: mailto:support@qloapps.com.
-
-### Documentation & Demo
-
-#### QloApps Documentation
-[https://docs.qloapps.com](https://docs.qloapps.com)
-#### QloApps Demo
-**Link** : https://demo.qloapps.com </br>
-**username** : demo@demo.com </br>
-**Password** : demodemo </br>
-
-### Contribute
-As a PHP developer who has command on PHP and MySQL and also knows how to use Git or GitHub efficiently, can contribute to code enhancements via pull requests.<br>
-For more information about the contribution process please check **[Contribute to QloApps](/CONTRIBUTING.md)**
-
-### Credits
-Crafted with :heart: at [Webkul](https://webkul.com)
+## License
+The original QloApps core remains licensed under OSL-3.0. Custom additions in this fork inherit the same license unless stated otherwise. Review [`LICENSE.md`](LICENSE.md) for details.

--- a/checklist.md
+++ b/checklist.md
@@ -1,0 +1,14 @@
+# Development Checklist
+
+## Completed
+- [x] Introduced `config/defines_custom.inc.php` with distribution feature flags.
+- [x] Disabled QloApps marketplace lookups in Tools and admin controllers.
+
+## In Progress
+- [ ] Draft resource taxonomy for rooms, ateliers, gastronomy areas.
+- [ ] Prototype HS/3-style resource timeline in admin calendar.
+
+## Planned
+- [ ] Replace cart-based booking flow with inquiry submission pipeline.
+- [ ] Rebuild front-office templates around availability storytelling.
+- [ ] Implement export utilities (CSV/ICS) for residency scheduling.

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3376,6 +3376,10 @@ exit;
     protected static $is_addons_up = true;
     public static function addonsRequest($request, $params = array())
     {
+        if (defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_) {
+            self::$is_addons_up = false;
+            return false;
+        }
         if (!self::$is_addons_up) {
             return false;
         }
@@ -3484,6 +3488,11 @@ exit;
      */
     public static function refresh($file_to_refresh, $external_file)
     {
+        if (defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_) {
+            self::$is_addons_up = false;
+            return false;
+        }
+
         if (self::$is_addons_up && $content = Tools::file_get_contents($external_file)) {
             return (bool)file_put_contents(_PS_ROOT_DIR_.$file_to_refresh, $content);
         }

--- a/concept.md
+++ b/concept.md
@@ -1,0 +1,27 @@
+# Kunstort Lehnin Hotel Management Concept
+
+## Vision
+Create a lean, fully self-hosted hospitality operations tool tailored to Kunstort Lehnin. The software prioritizes clarity of resource availability (Zimmer, Ateliers, Programmflächen) and enquiry-driven workflows over e-commerce features. It keeps the existing QloApps data model as a base while progressively reshaping it into a focused residency and guest management system.
+
+## Guiding Principles
+- **No third-party marketplaces**: disable all integrations with paid module stores and focus on in-repo extensibility.
+- **Inquiry-first operations**: pivot away from shopping carts to HS/3-style booking timelines and manual confirmation flows.
+- **Modular but transparent**: retain the ability to build custom modules from source without any proprietary dependencies.
+- **Campus-wide planning**: a unified calendar must represent rooms, studios, seminar spaces and events side-by-side.
+
+## Current Architecture Notes
+- The `hotelreservationsystem` module remains the functional core (ObjectModels for rooms, bookings, pricing).
+- PrestaShop marketplace hooks have been disabled globally via `_QLOAPP_DISABLE_MARKETPLACE_`.
+- Admin module catalogue interactions are short-circuited to keep the back office free from external promotions.
+- `config/defines_custom.inc.php` houses feature flags for the Kunstort distribution (e.g. `_KUNSTORT_CORE_MODE_ = 'inquiry'`).
+
+## Near-Term Roadmap
+1. **Calendar refactor**: extend the existing admin FullCalendar view into a resource timeline; expose it read-only in front office.
+2. **Inquiry workflow**: new controller & UI to log stay requests, decoupled from the PrestaShop cart.
+3. **Resource taxonomy**: introduce `resource_kind` and related metadata to rooms to cover Außenzimmer, Ateliers, Café etc.
+4. **Frontend narrative**: replace price-driven templates with curated descriptions and availability cues.
+
+## Longer-Term Ideas
+- Replace leftover commerce terminology in the database schema and UI strings.
+- Introduce CSV/ICS export for residency and seminar planning.
+- Build bridges to Kunstort's public programme website for event publishing.

--- a/config/defines_custom.inc.php
+++ b/config/defines_custom.inc.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Custom runtime flags for the Kunstort Lehnin distribution.
+ */
+if (!defined('_KUNSTORT_CORE_MODE_')) {
+    define('_KUNSTORT_CORE_MODE_', 'inquiry');
+}
+
+if (!defined('_QLOAPP_DISABLE_MARKETPLACE_')) {
+    define('_QLOAPP_DISABLE_MARKETPLACE_', true);
+}

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -59,6 +59,11 @@ class AdminModulesControllerCore extends AdminController
     protected $iso_default_country;
     protected $filter_configuration = array();
 
+    protected function isMarketplaceEnabled()
+    {
+        return !(defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_);
+    }
+
     /**
      * Admin Modules Controller Constructor
      * Init list modules categories
@@ -120,23 +125,25 @@ class AdminModulesControllerCore extends AdminController
         ));
 
         // Load cache file modules list (natives and partners modules)
-        $xml_modules = false;
-        if (file_exists(_PS_ROOT_DIR_.Module::CACHE_FILE_MODULES_LIST)) {
-            $xml_modules = @simplexml_load_file(_PS_ROOT_DIR_.Module::CACHE_FILE_MODULES_LIST);
-        }
-        if ($xml_modules) {
-            foreach ($xml_modules->children() as $xml_module) {
-                /** @var SimpleXMLElement $xml_module */
-                foreach ($xml_module->children() as $module) {
-                    /** @var SimpleXMLElement $module */
-                    foreach ($module->attributes() as $key => $value) {
-                        if (($xml_module->attributes() == 'native' || $xml_module->attributes() == 'disk')
-                            && $key == 'name'
-                        ) {
-                            $this->list_natives_modules[] = (string)$value;
-                        }
-                        if ($xml_module->attributes() == 'partner' && $key == 'name') {
-                            $this->list_partners_modules[] = (string)$value;
+        if ($this->isMarketplaceEnabled()) {
+            $xml_modules = false;
+            if (file_exists(_PS_ROOT_DIR_.Module::CACHE_FILE_MODULES_LIST)) {
+                $xml_modules = @simplexml_load_file(_PS_ROOT_DIR_.Module::CACHE_FILE_MODULES_LIST);
+            }
+            if ($xml_modules) {
+                foreach ($xml_modules->children() as $xml_module) {
+                    /** @var SimpleXMLElement $xml_module */
+                    foreach ($xml_module->children() as $module) {
+                        /** @var SimpleXMLElement $module */
+                        foreach ($module->attributes() as $key => $value) {
+                            if (($xml_module->attributes() == 'native' || $xml_module->attributes() == 'disk')
+                                && $key == 'name'
+                            ) {
+                                $this->list_natives_modules[] = (string)$value;
+                            }
+                            if ($xml_module->attributes() == 'partner' && $key == 'name') {
+                                $this->list_partners_modules[] = (string)$value;
+                            }
                         }
                     }
                 }
@@ -164,13 +171,19 @@ class AdminModulesControllerCore extends AdminController
         ));
         $this->addJS(_PS_JS_DIR_.'admin/modules.js');
 
-         if ($this->context->mode == Context::MODE_HOST && Tools::isSubmit('addnewmodule')) {
+        if ($this->isMarketplaceEnabled() && $this->context->mode == Context::MODE_HOST && Tools::isSubmit('addnewmodule')) {
             $this->addJS(_PS_JS_DIR_.'admin/addons.js');
         }
     }
 
     public function ajaxProcessRefreshModuleList($force_reload_cache = false)
     {
+        if (!$this->isMarketplaceEnabled()) {
+            $this->status = 'disabled';
+            echo json_encode(array('status' => $this->status));
+            return;
+        }
+
         // Refresh modules_list.xml every week
         if (!Tools::isFresh(Module::CACHE_FILE_MODULES_LIST, _TIME_1_DAY_) || $force_reload_cache) {
             $xml_modules_list = _QLO_API_DOMAIN_.'/xml/'.str_replace('.', '', _QLOAPPS_VERSION_).'.xml';
@@ -230,6 +243,10 @@ class AdminModulesControllerCore extends AdminController
 
     public function ajaxProcessLogOnAddonsWebservices()
     {
+        if (!$this->isMarketplaceEnabled()) {
+            die('DISABLED');
+        }
+
         $content = Tools::addonsRequest('check_customer', array('username_addons' => pSQL(trim(Tools::getValue('username_addons'))), 'password_addons' => pSQL(trim(Tools::getValue('password_addons')))));
         $xml = @simplexml_load_string($content, null, LIBXML_NOCDATA);
         if (!$xml) {

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -3047,7 +3047,10 @@ class AdminThemesControllerCore extends AdminController
         parent::setMedia();
         $this->addJS(_PS_JS_DIR_.'admin/themes.js');
 
-        if ($this->context->mode == Context::MODE_HOST && Tools::getValue('action') == 'importtheme') {
+        if (!(defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_)
+            && $this->context->mode == Context::MODE_HOST
+            && Tools::getValue('action') == 'importtheme'
+        ) {
             $this->addJS(_PS_JS_DIR_.'admin/addons.js');
         }
     }


### PR DESCRIPTION
## Summary
- add custom distribution flags to disable marketplace traffic and mark inquiry mode
- short-circuit marketplace lookups in Tools and admin controllers to keep the back office local-only
- replace the README with Kunstort-specific documentation and add concept/checklist roadmaps

## Testing
- php -l config/defines_custom.inc.php
- php -l classes/Tools.php
- php -l controllers/admin/AdminModulesController.php
- php -l controllers/admin/AdminThemesController.php

------
https://chatgpt.com/codex/tasks/task_e_68d2930d67608321a85d85c5b9c188b3