### PR TITLE
Disable addons marketplace UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Key characteristics of the fork:
 - 🧩 **Extensible from source** – custom modules can still be developed and dropped into `modules/` without depending on proprietary services.
 - 📆 **Calendar first** – upcoming development focuses on a resource timeline covering rooms, ateliers, seminar rooms and programme spaces.
 - 📨 **Inquiry workflow** – the shopping-cart driven booking journey will be replaced with curated requests that staff confirm manually.
+- 🔌 **Offline-friendly admin** – the Addons and Theme catalogues show local installation guidance instead of remote marketplace iframes.
 
 The high-level concept and roadmap live in [`concept.md`](concept.md). Tactical progress is tracked in [`checklist.md`](checklist.md).
 

--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -38,8 +38,14 @@ if (Tools::isSubmit('ajaxReferrers')) {
     require(_PS_CONTROLLER_DIR_.'admin/AdminReferrersController.php');
 }
 
-if (Tools::getValue('page') == 'prestastore' and @fsockopen('addons.prestashop.com', 80, $errno, $errst, 3)) {
-    readfile('http://addons.prestashop.com/adminmodules.php?lang='.$context->language->iso_code);
+if (Tools::getValue('page') == 'prestastore') {
+    if (defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_) {
+        header('HTTP/1.1 404 Not Found');
+        exit;
+    }
+    if (@fsockopen('addons.prestashop.com', 80, $errno, $errst, 3)) {
+        readfile('http://addons.prestashop.com/adminmodules.php?lang='.$context->language->iso_code);
+    }
 }
 
 if (Tools::isSubmit('getAvailableFields') and Tools::isSubmit('entity')) {

--- a/admin/themes/default/template/controllers/addons_catalog/content.tpl
+++ b/admin/themes/default/template/controllers/addons_catalog/content.tpl
@@ -22,8 +22,16 @@
 *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 *}
-{if $display_addons_content}
-	{$addons_content}
+{if $marketplace_disabled}
+        <div class="alert alert-info">
+                <h4>{l s='Marketplace disabled'}</h4>
+                <p>{l s='Remote marketplace content has been disabled for this distribution. Manage modules from source directly within your installation.'}</p>
+        </div>
+{elseif $display_addons_content}
+        {$addons_content}
 {else}
-	<iframe class="clearfix" style="margin:0px;padding:0px;width:100%;height:920px;overflow:hidden;border:none" src="//addons.prestashop.com/iframe/search.php?isoLang={$iso_lang}&amp;isoCurrency={$iso_currency}&amp;isoCountry={$iso_country}&amp;parentUrl={$parent_domain}"></iframe>
+        <div class="alert alert-warning">
+                <h4>{l s='Marketplace unavailable'}</h4>
+                <p>{l s='The PrestaShop Addons service could not be reached. Try again later or install modules manually from source.'}</p>
+        </div>
 {/if}

--- a/admin/themes/default/template/controllers/modules/content.tpl
+++ b/admin/themes/default/template/controllers/modules/content.tpl
@@ -27,67 +27,94 @@
 	{$module_content}
 {else}
 
-	{if isset($smarty.get.addnewmodule) && ($context_mode == Context::MODE_HOST)}
+{if isset($smarty.get.addnewmodule) && ($context_mode == Context::MODE_HOST)}
 
-		<div class="defaultForm form-horizontal">
+                <div class="defaultForm form-horizontal">
 
-			{if $logged_on_addons}
+                        {if $marketplace_disabled}
 
-				<div class="panel">
-					<div class="row">
-						<div class="col-lg-3 col-md-4 col-sm-12 col-xs-12">
-							<img class="img-responsive" alt="QloApps Addons" src="themes/default/img/prestashop-addons-logo.png">
-						</div>
-						<div class="col-lg-4 col-lg-offset-1 col-md-4 col-sm-7 col-xs-12 addons-style-search-bar">
-							<form id="addons-search-form" method="get" action="http://addons.prestashop.com/{$iso_code}/search" class="float">
-							<label>{l s='Search on PrestaShop Marketplace:'}</label>
-							<div class="input-group">
-								<input id="addons-search-box" class="form-control" type="text" autocomplete="off" name="query" value="" placeholder="Search on PrestaShop Marketplace">
-								<div id="addons-search-btn" class="btn btn-primary input-group-addon">
-									<i class="icon-search"></i>
-								</div>
-							</div>
-							</form>
-						</div>
-						<div class="col-lg-3 col-md-4 col-sm-5 col-xs-12 addons-see-all-themes">
-							{l s='Or'}<a href="http://addons.prestashop.com/{$iso_code}/2-modules-prestashop" class="btn btn-primary" onclick="return !window.open(this.href)">{l s='See all modules'}</a>
-						</div>
-					</div>
-				</div>
+                                <div class="panel" id="">
+                                        <div class="panel-heading">
+                                                <i class="icon-puzzle-piece"></i> {l s='Install modules from source'}
+                                        </div>
 
-			{else}
+                                        <div class="form-wrapper">
+                                                <div class="form-group">
+                                                        <p>{l s='Marketplace connectivity is disabled. Upload module ZIP archives directly or place them into the \"modules/\" directory to make them available.'}</p>
+                                                </div>
+                                                <div class="form-group">
+                                                        <p class="help-block">{l s='Use the manual upload form below to install new functionality.'}</p>
+                                                </div>
+                                        </div><!-- /.form-wrapper -->
 
-				<div class="panel" id="">
-					<div class="panel-heading">
-						<i class="icon-picture"></i> {l s='Add a new module'}
-					</div>
+                                        <div class="panel-footer">
+                                                <a href="{$link->getAdminLink('AdminModules', true)|escape:'html':'UTF-8'}" class="btn btn-default">
+                                                        <i class="process-icon-cancel"></i> {l s='Back to modules'}
+                                                </a>
+                                        </div>
+                                </div>
 
-					<div class="form-wrapper">
-						<div class="form-group">
-							<p>{l s='To add a new module, simply connect to your QloApps Addons account and all your purchases will be automatically imported.'}</p>
-						</div>
-					</div><!-- /.form-wrapper -->
+                        {else}
 
-					<div class="panel-footer">
-						<a href="{$link->getAdminLink('AdminModules', true)|escape:'html':'UTF-8'}" class="btn btn-default">
-							<i class="process-icon-cancel"></i> {l s='Cancel'}
-						</a>
-						<a href="#" data-toggle="modal" data-target="#modal_addons_connect" class="btn btn-default pull-right">
-							<i class="process-icon-next"></i> {l s='Next'}
-						</a>
-					</div>
-				</div>
+                                {if $logged_on_addons}
 
-			{/if}
+                                        <div class="panel">
+                                                <div class="row">
+                                                        <div class="col-lg-3 col-md-4 col-sm-12 col-xs-12">
+                                                                <img class="img-responsive" alt="QloApps Addons" src="themes/default/img/prestashop-addons-logo.png">
+                                                        </div>
+                                                        <div class="col-lg-4 col-lg-offset-1 col-md-4 col-sm-7 col-xs-12 addons-style-search-bar">
+                                                                <form id="addons-search-form" method="get" action="http://addons.prestashop.com/{$iso_code}/search" class="float">
+                                                                <label>{l s='Search on PrestaShop Marketplace:'}</label>
+                                                                <div class="input-group">
+                                                                        <input id="addons-search-box" class="form-control" type="text" autocomplete="off" name="query" value="" placeholder="Search on PrestaShop Marketplace">
+                                                                        <div id="addons-search-btn" class="btn btn-primary input-group-addon">
+                                                                                <i class="icon-search"></i>
+                                                                        </div>
+                                                                </div>
+                                                                </form>
+                                                        </div>
+                                                        <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12 addons-see-all-themes">
+                                                                {l s='Or'}<a href="http://addons.prestashop.com/{$iso_code}/2-modules-prestashop" class="btn btn-primary" onclick="return !window.open(this.href)">{l s='See all modules'}</a>
+                                                        </div>
+                                                </div>
+                                        </div>
 
-				<div class="alert alert-info">
-					<h4>{l s='Can I add my own modules?'}</h4>
-					<p>{l s='Please note that for security reasons, you can only add modules that are being distributed on QloApps Addons, the official marketplace.'}</p>
-				</div>
+                                {else}
 
-		</div>
+                                        <div class="panel" id="">
+                                                <div class="panel-heading">
+                                                        <i class="icon-picture"></i> {l s='Add a new module'}
+                                                </div>
 
-	{elseif !isset($smarty.get.configure)}
+                                                <div class="form-wrapper">
+                                                        <div class="form-group">
+                                                                <p>{l s='To add a new module, simply connect to your QloApps Addons account and all your purchases will be automatically imported.'}</p>
+                                                        </div>
+                                                </div><!-- /.form-wrapper -->
+
+                                                <div class="panel-footer">
+                                                        <a href="{$link->getAdminLink('AdminModules', true)|escape:'html':'UTF-8'}" class="btn btn-default">
+                                                                <i class="process-icon-cancel"></i> {l s='Cancel'}
+                                                        </a>
+                                                        <a href="#" data-toggle="modal" data-target="#modal_addons_connect" class="btn btn-default pull-right">
+                                                                <i class="process-icon-next"></i> {l s='Next'}
+                                                        </a>
+                                                </div>
+                                        </div>
+
+                                {/if}
+
+                                <div class="alert alert-info">
+                                        <h4>{l s='Can I add my own modules?'}</h4>
+                                        <p>{l s='Please note that for security reasons, you can only add modules that are being distributed on QloApps Addons, the official marketplace.'}</p>
+                                </div>
+
+                        {/if}
+
+                </div>
+
+{elseif !isset($smarty.get.configure)}
 		{include file='controllers/modules/js.tpl'}
 		{include file='controllers/modules/page.tpl'}
 	{/if}

--- a/admin/themes/default/template/controllers/modules/js.tpl
+++ b/admin/themes/default/template/controllers/modules/js.tpl
@@ -43,7 +43,13 @@
 
 	{literal}
 
-	function getPrestaStore(){if(getE("prestastore").style.display!='block')return;$.post(dirNameCurrentIndex+"/ajax.php",{page:"prestastore"},function(a){getE("prestastore-content").innerHTML=a;})}
+        function getPrestaStore(){
+{if $marketplace_disabled}
+            return;
+{else}
+            if(getE("prestastore").style.display!='block')return;$.post(dirNameCurrentIndex+"/ajax.php",{page:"prestastore"},function(a){getE("prestastore-content").innerHTML=a;})
+{/if}
+        }
 	function truncate_author(author){return ((author.length > 20) ? author.substring(0, 20)+"..." : author);}
 	function modules_management(action)
 	{
@@ -155,28 +161,30 @@
 		});
 
 		// Method to get modules_list.xml from prestashop.com and default_country_modules_list.xml from addons.prestashop.com
-		try
-		{
-			resAjax = $.ajax({
-				type:"POST",
-				url: ajaxCurrentIndex,
-				headers: {"cache-control": "no-cache"},
-				async: true,
-				cache: false,
-				data: {
-					ajaxMode : "1",
-					ajax : "1",
-					token : token,
-					controller : "AdminModules",
-					action : "refreshModuleList"
-				},
-				success: function(data){
-					if (data == '{"status":"refresh"}')
-						window.location.href = window.location.href;
-				}
-			});
-		}
-		catch(e) { }
+{if !$marketplace_disabled}
+                try
+                {
+                        resAjax = $.ajax({
+                                type:"POST",
+                                url: ajaxCurrentIndex,
+                                headers: {"cache-control": "no-cache"},
+                                async: true,
+                                cache: false,
+                                data: {
+                                        ajaxMode : "1",
+                                        ajax : "1",
+                                        token : token,
+                                        controller : "AdminModules",
+                                        action : "refreshModuleList"
+                                },
+                                success: function(data){
+                                        if (data == '{"status":"refresh"}')
+                                                window.location.href = window.location.href;
+                                }
+                        });
+                }
+                catch(e) { }
+{/if}
 
 		// Method to set filter on modules
 		function setFilter()

--- a/admin/themes/default/template/controllers/modules/login_addons.tpl
+++ b/admin/themes/default/template/controllers/modules/login_addons.tpl
@@ -25,10 +25,15 @@
 
 <div class="modal-body">
 {if $add_permission eq '1'}
-	{if !isset($logged_on_addons) || !$logged_on_addons}
-		{if $check_url_fopen eq 'ko'  OR $check_openssl eq 'ko'}
-			<div class="alert alert-warning">
-				{l s='If you want to be able to fully use the AdminModules panel and have free modules available, you should enable the following configuration on your server:'}
+        {if isset($marketplace_disabled) && $marketplace_disabled}
+                <div class="alert alert-info">
+                        <h4>{l s='Marketplace disabled'}</h4>
+                        <p>{l s='This distribution operates without the PrestaShop Addons marketplace. Install modules by uploading ZIP archives directly in the Modules page.'}</p>
+                </div>
+        {elseif !isset($logged_on_addons) || !$logged_on_addons}
+                {if $check_url_fopen eq 'ko'  OR $check_openssl eq 'ko'}
+                        <div class="alert alert-warning">
+                                {l s='If you want to be able to fully use the AdminModules panel and have free modules available, you should enable the following configuration on your server:'}
 				<br />
 				{if $check_url_fopen eq 'ko'}- {l s='Enable PHP\'s allow_url_fopen setting'}<br />{/if}
 				{if $check_openssl eq 'ko'}- {l s='Enable PHP\'s OpenSSL extension'}<br />{/if}

--- a/admin/themes/default/template/controllers/themes/helpers/form/form.tpl
+++ b/admin/themes/default/template/controllers/themes/helpers/form/form.tpl
@@ -25,68 +25,93 @@
 {extends file="helpers/form/form.tpl"}
 
 {block name="defaultForm"}
-	{if $context_mode == Context::MODE_HOST && isset($import_theme) && $import_theme}
+        {if $context_mode == Context::MODE_HOST && isset($import_theme) && $import_theme}
 
-	<div class="defaultForm form-horizontal">
-		{if $logged_on_addons}
+        <div class="defaultForm form-horizontal">
+                {if $marketplace_disabled}
 
-			<div class="panel">
-				<div class="row">
-					<div class="col-lg-3 col-md-4 col-sm-12 col-xs-12">
-						<img class="img-responsive" alt="PrestaShop Addons" src="themes/default/img/prestashop-addons-logo.png">
-					</div>
-					<div class="col-lg-4 col-lg-offset-1 col-md-4 col-sm-7 col-xs-12 addons-style-search-bar">
-						<form id="addons-search-form" method="get" action="http://addons.prestashop.com/{$iso_code}/search" class="float">
-						<label>{l s='Search on PrestaShop Marketplace:'}</label>
-						<div class="input-group">
-							<input id="addons-search-box" class="form-control" type="text" autocomplete="off" name="query" value="" placeholder="Search on PrestaShop Marketplace">
-							<div id="addons-search-btn" class="btn btn-primary input-group-addon">
-								<i class="icon-search"></i>
-							</div>
-						</div>
-						</form>
-					</div>
-					<div class="col-lg-3 col-md-4 col-sm-5 col-xs-12 addons-see-all-themes">
-						{l s='Or'}<a href="http://addons.prestashop.com/{$iso_code}/3-templates-prestashop" class="btn btn-primary" onclick="return !window.open(this.href)p">{l s='See all themes'}</a>
-					</div>
-				</div>
-			</div>
+                        <div class="panel" id="">
+                                <div class="panel-heading">
+                                        <i class="icon-picture"></i> {l s='Import themes from your server'}
+                                </div>
 
-		{else}
+                                <div class="form-wrapper">
+                                        <div class="form-group">
+                                                <p>{l s='Marketplace connectivity is disabled. Upload your custom theme archives via FTP or the manual uploader to make them available.'}</p>
+                                        </div>
+                                        <div class="form-group">
+                                                <p class="help-block">{l s='Place ZIP files inside the /themes directory or use the manual upload option below.'}</p>
+                                        </div>
+                                </div><!-- /.form-wrapper -->
 
-			<div class="panel" id="">
-				<div class="panel-heading">
-					<i class="icon-picture"></i> {l s='Add a new theme'}
-				</div>
+                                <div class="panel-footer">
+                                        <a href="{$link->getAdminLink('AdminThemes', true)|escape:'html':'UTF-8'}" class="btn btn-default">
+                                                <i class="process-icon-cancel"></i> {l s='Back to themes'}
+                                        </a>
+                                </div>
+                        </div>
 
-				<div class="form-wrapper">
-					<div class="form-group">
-						<p>{l s='To add a new theme, simply connect to your PrestaShop Addons account: your new theme will be automatically imported to your shop.'}</p>
-						<p>{l s='You can choose among 1,500+ professional templates!'}</p>
-					</div>
-				</div><!-- /.form-wrapper -->
+                {elseif $logged_on_addons}
 
-				<div class="panel-footer">
-					<a href="{$link->getAdminLink('AdminThemes', true)|escape:'html':'UTF-8'}" class="btn btn-default">
-						<i class="process-icon-cancel"></i> {l s='Cancel'}
-					</a>
-					<a href="#" data-toggle="modal" data-target="#modal_addons_connect" class="btn btn-default pull-right">
-						<i class="process-icon-next"></i> {l s='Next'}
-					</a>
-				</div>
-			</div>
+                        <div class="panel">
+                                <div class="row">
+                                        <div class="col-lg-3 col-md-4 col-sm-12 col-xs-12">
+                                                <img class="img-responsive" alt="PrestaShop Addons" src="themes/default/img/prestashop-addons-logo.png">
+                                        </div>
+                                        <div class="col-lg-4 col-lg-offset-1 col-md-4 col-sm-7 col-xs-12 addons-style-search-bar">
+                                                <form id="addons-search-form" method="get" action="http://addons.prestashop.com/{$iso_code}/search" class="float">
+                                                <label>{l s='Search on PrestaShop Marketplace:'}</label>
+                                                <div class="input-group">
+                                                        <input id="addons-search-box" class="form-control" type="text" autocomplete="off" name="query" value="" placeholder="Search on PrestaShop Marketplace">
+                                                        <div id="addons-search-btn" class="btn btn-primary input-group-addon">
+                                                                <i class="icon-search"></i>
+                                                        </div>
+                                                </div>
+                                                </form>
+                                        </div>
+                                        <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12 addons-see-all-themes">
+                                                {l s='Or'}<a href="http://addons.prestashop.com/{$iso_code}/3-templates-prestashop" class="btn btn-primary" onclick="return !window.open(this.href)p">{l s='See all themes'}</a>
+                                        </div>
+                                </div>
+                        </div>
 
-		{/if}
+                {else}
 
-			<div class="alert alert-info">
-				<h4>{l s='Can I add my own theme?'}</h4>
-				<p>{l s='Please note that for security reasons, you can only add themes that are being distributed on PrestaShop Addons, the official marketplace.'}</p>
-				<p>{l s='You can also create a new theme below.'}</p>
-			</div>
+                        <div class="panel" id="">
+                                <div class="panel-heading">
+                                        <i class="icon-picture"></i> {l s='Add a new theme'}
+                                </div>
 
-	</div>
+                                <div class="form-wrapper">
+                                        <div class="form-group">
+                                                <p>{l s='To add a new theme, simply connect to your PrestaShop Addons account: your new theme will be automatically imported to your shop.'}</p>
+                                                <p>{l s='You can choose among 1,500+ professional templates!'}</p>
+                                        </div>
+                                </div><!-- /.form-wrapper -->
 
-	{else}
-		{$smarty.block.parent}
-	{/if}
+                                <div class="panel-footer">
+                                        <a href="{$link->getAdminLink('AdminThemes', true)|escape:'html':'UTF-8'}" class="btn btn-default">
+                                                <i class="process-icon-cancel"></i> {l s='Cancel'}
+                                        </a>
+                                        <a href="#" data-toggle="modal" data-target="#modal_addons_connect" class="btn btn-default pull-right">
+                                                <i class="process-icon-next"></i> {l s='Next'}
+                                        </a>
+                                </div>
+                        </div>
+
+                {/if}
+
+                {if !$marketplace_disabled}
+                        <div class="alert alert-info">
+                                <h4>{l s='Can I add my own theme?'}</h4>
+                                <p>{l s='Please note that for security reasons, you can only add themes that are being distributed on PrestaShop Addons, the official marketplace.'}</p>
+                                <p>{l s='You can also create a new theme below.'}</p>
+                        </div>
+                {/if}
+
+        </div>
+
+        {else}
+                {$smarty.block.parent}
+        {/if}
 {/block}

--- a/checklist.md
+++ b/checklist.md
@@ -3,6 +3,7 @@
 ## Completed
 - [x] Introduced `config/defines_custom.inc.php` with distribution feature flags.
 - [x] Disabled QloApps marketplace lookups in Tools and admin controllers.
+- [x] Replaced marketplace catalog UIs with offline guidance when remote services are disabled.
 
 ## In Progress
 - [ ] Draft resource taxonomy for rooms, ateliers, gastronomy areas.

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2470,7 +2470,9 @@ class AdminControllerCore extends Controller
      */
     public function initModal()
     {
-        if ($this->logged_on_addons) {
+        $marketplace_disabled = defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_;
+
+        if ($this->logged_on_addons && !$marketplace_disabled) {
             $this->context->smarty->assign(array(
                 'logged_on_addons' => 1,
                 'username_addons' => $this->context->cookie->username_addons
@@ -2484,7 +2486,8 @@ class AdminControllerCore extends Controller
             'check_url_fopen' => (ini_get('allow_url_fopen') ? 'ok' : 'ko'),
             'check_openssl' => (extension_loaded('openssl') ? 'ok' : 'ko'),
             'add_permission' => 1,
-            'addons_register_link' => 'https://addons.prestashop.com/'.$this->context->language->iso_code.'/login'
+            'addons_register_link' => $marketplace_disabled ? '' : 'https://addons.prestashop.com/'.$this->context->language->iso_code.'/login',
+            'marketplace_disabled' => $marketplace_disabled,
         ));
 
         //Force override translation key

--- a/concept.md
+++ b/concept.md
@@ -14,6 +14,7 @@ Create a lean, fully self-hosted hospitality operations tool tailored to Kunstor
 - PrestaShop marketplace hooks have been disabled globally via `_QLOAPP_DISABLE_MARKETPLACE_`.
 - Admin module catalogue interactions are short-circuited to keep the back office free from external promotions.
 - `config/defines_custom.inc.php` houses feature flags for the Kunstort distribution (e.g. `_KUNSTORT_CORE_MODE_ = 'inquiry'`).
+- When marketplace access is disabled, admin catalogue and theme pages display offline guidance instead of loading remote iframes.
 
 ## Near-Term Roadmap
 1. **Calendar refactor**: extend the existing admin FullCalendar view into a resource timeline; expose it read-only in front office.

--- a/controllers/admin/AdminAddonsCatalogController.php
+++ b/controllers/admin/AdminAddonsCatalogController.php
@@ -34,21 +34,29 @@ class AdminAddonsCatalogControllerCore extends AdminController
 
     public function initContent()
     {
+        $marketplace_disabled = defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_;
         $parent_domain = Tools::getHttpHost(true).substr($_SERVER['REQUEST_URI'], 0, -1 * strlen(basename($_SERVER['REQUEST_URI'])));
         $iso_lang = $this->context->language->iso_code;
         $iso_currency = $this->context->currency->iso_code;
         $iso_country = $this->context->country->iso_code;
-        $activity = Configuration::get('PS_SHOP_ACTIVITY');
-        $addons_url = 'http://addons.prestashop.com/iframe/search-1.6.php?psVersion='._PS_VERSION_.'&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain;
-        $addons_content = Tools::file_get_contents($addons_url);
+
+        $addons_content = '';
+        $display_addons_content = false;
+        if (!$marketplace_disabled) {
+            $activity = Configuration::get('PS_SHOP_ACTIVITY');
+            $addons_url = 'http://addons.prestashop.com/iframe/search-1.6.php?psVersion='._PS_VERSION_.'&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain;
+            $addons_content = Tools::file_get_contents($addons_url);
+            $display_addons_content = $addons_content !== false;
+        }
 
         $this->context->smarty->assign(array(
             'iso_lang' => $iso_lang,
             'iso_currency' => $iso_currency,
             'iso_country' => $iso_country,
-            'display_addons_content' => $addons_content !== false,
+            'display_addons_content' => $display_addons_content,
             'addons_content' => $addons_content,
             'parent_domain' => $parent_domain,
+            'marketplace_disabled' => $marketplace_disabled,
         ));
 
         parent::initContent();

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1643,7 +1643,8 @@ class AdminModulesControllerCore extends AdminController
             'modules_uri' => __PS_BASE_URI__.basename(_PS_MODULE_DIR_),
             'dont_filter' => $dont_filter,
             'is_contributor' => (int)$this->context->cookie->is_contributor,
-            'maintenance_mode' => !(bool)Configuration::Get('PS_SHOP_ENABLE')
+            'maintenance_mode' => !(bool)Configuration::Get('PS_SHOP_ENABLE'),
+            'marketplace_disabled' => !$this->isMarketplaceEnabled(),
         );
 
         if ($this->logged_on_addons) {

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -306,7 +306,9 @@ class AdminSearchControllerCore extends AdminController
                 }
             }
 
-            if (!is_numeric(trim($this->query)) && !Validate::isEmail($this->query)) {
+            if (!is_numeric(trim($this->query)) && !Validate::isEmail($this->query)
+                && !(defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_)
+            ) {
                 $iso_lang = Tools::strtolower(Context::getContext()->language->iso_code);
                 $iso_country = Tools::strtolower(Country::getIsoById(Configuration::get('PS_COUNTRY_DEFAULT')));
                 if (($json_content = Tools::file_get_contents('https://api-addons.prestashop.com/'._PS_VERSION_.'/search/'.urlencode($this->query).'/'.$iso_country.'/'.$iso_lang.'/')) != false) {

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -1868,6 +1868,7 @@ class AdminThemesControllerCore extends AdminController
                 'iso_code' => $this->context->language->iso_code,
                 'add_new_theme_href' => self::$currentIndex.'&addtheme&token='.$this->token,
                 'add_new_theme_label' => $this->l('Create a new theme'),
+                'marketplace_disabled' => (int)(defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_),
             )
         );
 
@@ -1927,6 +1928,9 @@ class AdminThemesControllerCore extends AdminController
 
     public function ajaxProcessGetAddonsThemes()
     {
+        if (defined('_QLOAPP_DISABLE_MARKETPLACE_') && _QLOAPP_DISABLE_MARKETPLACE_) {
+            die('');
+        }
         $parent_domain = Tools::getHttpHost(true).substr($_SERVER['REQUEST_URI'], 0, -1 * strlen(basename($_SERVER['REQUEST_URI'])));
         $iso_lang = $this->context->language->iso_code;
         $iso_currency = $this->context->currency->iso_code;


### PR DESCRIPTION
## Summary
- short-circuit admin marketplace controllers when `_QLOAPP_DISABLE_MARKETPLACE_` is true
- replace Addons and Theme back office templates with offline guidance and disable remote ajax calls
- document the offline admin experience in the concept, checklist, and README

## Testing
- php -l controllers/admin/AdminAddonsCatalogController.php
- php -l controllers/admin/AdminSearchController.php
- php -l admin/ajax.php
- php -l controllers/admin/AdminModulesController.php
- php -l controllers/admin/AdminThemesController.php
- php -l classes/controller/AdminController.php

------
https://chatgpt.com/codex/tasks/task_e_68d2ddb38f4c8321abc6862e9e1c1aad