### PR TITLE
Add roadmap and align planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Key characteristics of the fork:
 - 🔒 **Legacy API removed** – `/webservice` now responds with HTTP 410 and the back office no longer advertises API key management.
 - 💳 **Payments deferred** – legacy bank wire, cheque and PayPal Commerce modules are stripped out so stays are confirmed and settled off-platform.
 
-The high-level concept and roadmap live in [`concept.md`](concept.md). Tactical progress is tracked in [`checklist.md`](checklist.md).
+The high-level concept lives in [`concept.md`](concept.md), the multi-phase plan in [`roadmap.md`](roadmap.md), and tactical progress in [`checklist.md`](checklist.md).
 
 ### Inquiry Landing
 

--- a/checklist.md
+++ b/checklist.md
@@ -16,6 +16,11 @@
 - [ ] Layer drag-and-drop reallocation controls onto the new booking timeline.
 
 ## Planned
+- [ ] Model a dedicated Inquiry entity plus Kanban board with assignment workflow.
+- [ ] Expose REST endpoints for timeline edits, inquiry status changes and availability lookups.
 - [ ] Build out the dedicated inquiry submission pipeline on top of the new entry point.
 - [ ] Rebuild front-office templates around availability storytelling.
+- [ ] Introduce configurable rate plans and bundled residency packages.
+- [ ] Implement housekeeping and maintenance task automation.
 - [ ] Implement export utilities (CSV/ICS) for residency scheduling.
+- [ ] Deliver utilisation dashboards and programme reporting.

--- a/concept.md
+++ b/concept.md
@@ -21,11 +21,13 @@ Create a lean, fully self-hosted hospitality operations tool tailored to Kunstor
 - The front-office header ships as a static residency navigation strip with in-house quick links; cart/account/newsletter/social blocks have been removed from both the theme and core module set so no commerce widgets are expected.
 - Legacy PrestaShop webservice entry points are stubbed; `/webservice` responds with HTTP 410 and no admin UI exposes API keys.
 
-## Near-Term Roadmap
-1. **Calendar refactor** *(ongoing)*: extend the admin booking view into a resource timeline (baseline timeline shipped; drag-and-drop management still pending); expose it read-only in front office.
-2. **Inquiry workflow**: new controller & UI to log stay requests, decoupled from the PrestaShop cart (checkout endpoints already forward to the inquiry landing page).
-3. **Resource taxonomy**: introduce `resource_kind` and related metadata to rooms to cover Außenzimmer, Ateliers, Café etc.
-4. **Frontend narrative**: replace price-driven templates with curated descriptions and availability cues.
+## Near-Term Focus
+The detailed multi-phase plan lives in [`roadmap.md`](roadmap.md). Immediate priorities concentrate on the first roadmap phases:
+
+1. **Timeline interaction upgrades** *(in progress)* – finish the drag-and-drop reallocation tools and collision checks for the admin timeline, then surface read-only availability to the public site.
+2. **Inquiry workflow foundations** – carve out a dedicated Inquiry model, Kanban board and assignment flow so booking management no longer depends on carts.
+3. **Resource taxonomy groundwork** – model `resource_kind`, capacity descriptors and amenities on rooms, ateliers and gastronomy spaces to unlock richer storytelling and reporting.
+4. **Frontend storytelling** – refactor offer pages to present curated narratives, availability cues and inquiry entry points instead of commodity pricing widgets.
 
 ## Longer-Term Ideas
 - Replace leftover commerce terminology in the database schema and UI strings.

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,31 @@
+# Kunstort Lehnin Roadmap
+
+This roadmap tracks how the Kunstort Lehnin fork evolves from a de-bloated QloApps baseline into a residency-first operations suite. Each phase groups together coherent deliverables so we can prioritise work and spot dependencies early. Status markers: ✅ complete, 🚧 in progress, ⏳ planned.
+
+## Phase 0 – Commerce Debloating (✅ Complete)
+- ✅ **Checkout short-circuit** – `order`/`order-opc` controllers render the inquiry landing and the matching theme templates only display the manual booking guidance.
+- ✅ **Payment modules removed** – legacy `bankwire`, `cheque` and `qlopaypalcommerce` modules (and overrides) are no longer shipped so no unused PCI-facing code stays in the tree.
+- ✅ **Front-office widgets stripped** – header and column slots now render a static residency navigation without cart, account, newsletter or social hooks.
+- ✅ **Webservice disabled** – `/webservice` responds with HTTP 410 and admin tooling for API keys has been excised to reduce attack surface.
+
+## Phase 1 – Inquiry Workflow Maturity (🚧 In progress)
+- 🚧 **Timeline interaction upgrades** – add drag-and-drop reallocation with conflict detection against room disables and capacity rules.
+- ⏳ **Inquiry entity & board** – replace cart-derived booking scaffolding with a dedicated Inquiry model, Kanban board UI and assignment workflow, including reminders and mail notes.
+- ⏳ **API endpoints** – expose REST endpoints for timeline updates, inquiry status changes and availability lookups to support the new UI components.
+
+## Phase 2 – Resource & Pricing Model (⏳ Planned)
+- ⏳ **Resource taxonomy** – add `resource_kind`, capacity descriptors and amenities metadata to rooms, ateliers, seminar spaces and gastronomy units.
+- ⏳ **Rate plans & packages** – introduce configurable price plans (BAR, corporate, residency programmes) plus bundled packages for weekly ateliers, catering-inclusive stays, etc.
+- ⏳ **Frontend storytelling** – rebuild offer pages to surface the new taxonomy with curated copy, imagery and availability cues.
+
+## Phase 3 – Operations Automation (⏳ Planned)
+- ⏳ **Housekeeping & maintenance tasks** – auto-generate cleaning and technical checklists from arrival/departure data and allow staff to report statuses (clean, in progress, needs repair).
+- ⏳ **Internal notifications** – hook inquiry and timeline events into task reminders, digest emails and calendar feeds for staff.
+- ⏳ **ICS/CSV exports** – deliver calendar and reporting exports for residency, seminar and event planning.
+
+## Phase 4 – Reporting & Integrations (⏳ Planned)
+- ⏳ **Utilisation dashboards** – surface occupancy, length-of-stay, residency programme metrics with filters by resource type.
+- ⏳ **Programme publishing bridge** – sync curated events and residencies to the public Kunstort Lehnin website or other storytelling channels.
+- ⏳ **External API strategy** – design modern, scoped APIs (authenticated modules, webhook patterns) to replace the retired PrestaShop webservice when needed.
+
+We iterate through the roadmap top-to-bottom: hardening the base, completing inquiry workflows, enriching resource data, automating internal operations, and finally exposing analytics and integrations once the core experience is stable.


### PR DESCRIPTION
## Summary
- add a dedicated roadmap.md that captures the multi-phase debloating and product plan
- align concept.md with the new roadmap focus areas and link all planning docs from the README
- expand the checklist to mirror the roadmap milestones for upcoming work

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d2fbefa0c48321b982647eb556ad2b