### PR TITLE
feat: add inquiry board and timeline reallocation APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Key characteristics of the fork:
 - 🧭 **Residency navigation** – the front-office header ships with a static residency nav bar and in-house quick links; cart/account/newsletter/social blocks have been excised from both the theme overrides and the module set.
 - 🔒 **Legacy API removed** – `/webservice` now responds with HTTP 410 and the back office no longer advertises API key management.
 - 💳 **Payments deferred** – legacy bank wire, cheque and PayPal Commerce modules are stripped out so stays are confirmed and settled off-platform.
+- 🔄 **Interactive timeline** – bookings can be reallocated by dragging directly on the admin timeline, with conflict checks against disabled rooms and occupancy caps.
+- 🗂️ **Inquiry board** – a Kanban-style board replaces cart scaffolding so inquiries can be triaged, assigned, noted and scheduled with reminders.
+- 🌐 **Scoped REST endpoints** – new JSON endpoints cover timeline moves, inquiry status changes and availability lookups without reviving the legacy webservice.
 
 The high-level concept lives in [`concept.md`](concept.md), the multi-phase plan in [`roadmap.md`](roadmap.md), and tactical progress in [`checklist.md`](checklist.md).
 
@@ -37,6 +40,29 @@ The back-office path **Hotel Reservation System → Booking** now presents a tab
 - **Search & Filters**: the booking form, occupancy selector and availability stats.
 
 Edits performed from the availability list or cart refresh both the timeline and (when initialised) the month grid so that staff always see the latest state.
+
+### Drag-and-Drop Reallocation
+
+Drag any booked cell from its start date to another room/day to trigger a reallocation preview. The timeline will validate the move against:
+
+- Existing bookings on the destination room.
+- Room disable ranges (maintenance/out-of-order blocks).
+- Room type capacity (adults, children and total guests).
+
+If the move is valid you can confirm the change directly from the drop action. Conflicts are listed inline so staff know why a move is blocked.
+
+### Availability API
+
+`index.php?controller=AdminHotelRoomsBooking&ajax=1&action=lookupAvailability` accepts `id_hotel`, `id_room_type`, `date_from` and `date_to` to return JSON payloads of available, booked and disabled rooms for the requested window. The timeline UI consumes the same endpoint.
+
+## Inquiry Board
+Navigate to **Hotel Reservation System → Inquiries** to triage, assign and progress residency requests. Each column represents a stage (Inbox, Qualifying, Awaiting reply, Scheduled, Archived) and cards expose:
+
+- Assignee dropdowns that fire async updates.
+- Reminder shortcuts (stored on the inquiry record) for follow-up scheduling.
+- Note capture with an optional “mail note” flag that doubles as an internal log of outbound responses.
+
+Dragging a card to another column automatically updates its stage (and default status), with conflict messaging if a move is not allowed.
 
 ## Resident-Focused Front Office
 
@@ -75,8 +101,7 @@ All Kunstort-specific flags live in `config/defines_custom.inc.php`:
 Use these constants in future contributions to gate legacy commerce flows.
 
 ## Development Priorities
-- Finish drag-and-drop management and resource annotations on the new tabbed booking timeline.
-- Introduce a unified resource taxonomy (rooms, ateliers, gastronomy) in the database and admin forms.
+- Broaden resource annotations (rooms, ateliers, gastronomy) to enrich availability storytelling and reporting.
 - Replace the front-office room list with storytelling-driven templates and an enquiry form.
 - Provide CSV/ICS exports to support residency and seminar scheduling outside the app.
 

--- a/checklist.md
+++ b/checklist.md
@@ -13,11 +13,19 @@
 
 ## In Progress
 - [ ] Draft resource taxonomy for rooms, ateliers, gastronomy areas.
-- [ ] Layer drag-and-drop reallocation controls onto the new booking timeline.
 
 ## Planned
-- [ ] Model a dedicated Inquiry entity plus Kanban board with assignment workflow.
-- [ ] Expose REST endpoints for timeline edits, inquiry status changes and availability lookups.
+- [ ] Build out the dedicated inquiry submission pipeline on top of the new entry point.
+- [ ] Rebuild front-office templates around availability storytelling.
+- [ ] Introduce configurable rate plans and bundled residency packages.
+- [ ] Implement housekeeping and maintenance task automation.
+- [ ] Implement export utilities (CSV/ICS) for residency scheduling.
+- [ ] Deliver utilisation dashboards and programme reporting.
+
+## Recently Completed
+- [x] Layered drag-and-drop reallocation controls onto the booking timeline with conflict detection.
+- [x] Modeled a dedicated Inquiry entity plus Kanban board with reminders, assignments and notes.
+- [x] Exposed REST endpoints for timeline edits, inquiry updates and availability lookups.
 - [ ] Build out the dedicated inquiry submission pipeline on top of the new entry point.
 - [ ] Rebuild front-office templates around availability storytelling.
 - [ ] Introduce configurable rate plans and bundled residency packages.

--- a/concept.md
+++ b/concept.md
@@ -18,14 +18,20 @@ Create a lean, fully self-hosted hospitality operations tool tailored to Kunstor
 - When `_KUNSTORT_CORE_MODE_` is set to `inquiry`, the legacy checkout controllers and templates short-circuit to the inquiry landing page instead of exposing cart mechanics.
 - When marketplace access is disabled, admin catalogue and theme pages display offline guidance instead of loading remote iframes.
 - The admin booking screen now opens with a tabbed occupancy timeline; the legacy month grid loads lazily only when the calendar tab is selected, and timeline data stays cached while the tab remains active for near-instant toggling.
+- Drag-and-drop reallocation is available directly on the occupancy timeline with server-side conflict checks against disabled rooms and capacity limits.
 - The front-office header ships as a static residency navigation strip with in-house quick links; cart/account/newsletter/social blocks have been removed from both the theme and core module set so no commerce widgets are expected.
 - Legacy PrestaShop webservice entry points are stubbed; `/webservice` responds with HTTP 410 and no admin UI exposes API keys.
+
+## Inquiry Workflow Additions
+- A dedicated Inquiry entity tracks residency requests independently from carts, including assignee, reminder, and note metadata.
+- The back office exposes an Inquiries Kanban board for triage, assignment, reminders and mail-style notes.
+- Timeline and inquiry APIs now expose JSON endpoints for UI interactions (reallocation, status changes, availability lookups) without reviving the legacy webservice.
 
 ## Near-Term Focus
 The detailed multi-phase plan lives in [`roadmap.md`](roadmap.md). Immediate priorities concentrate on the first roadmap phases:
 
-1. **Timeline interaction upgrades** *(in progress)* – finish the drag-and-drop reallocation tools and collision checks for the admin timeline, then surface read-only availability to the public site.
-2. **Inquiry workflow foundations** – carve out a dedicated Inquiry model, Kanban board and assignment flow so booking management no longer depends on carts.
+1. **Timeline interaction upgrades** *(complete)* – drag-and-drop reallocation on the admin timeline now blocks conflicts against disabled rooms and occupancy limits, and powers the new REST endpoints.
+2. **Inquiry workflow foundations** *(rolling out)* – the dedicated Inquiry model, Kanban board, reminders and mail notes replace cart-driven scaffolding in the back office.
 3. **Resource taxonomy groundwork** – model `resource_kind`, capacity descriptors and amenities on rooms, ateliers and gastronomy spaces to unlock richer storytelling and reporting.
 4. **Frontend storytelling** – refactor offer pages to present curated narratives, availability cues and inquiry entry points instead of commodity pricing widgets.
 

--- a/modules/hotelreservationsystem/classes/HotelInquiry.php
+++ b/modules/hotelreservationsystem/classes/HotelInquiry.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License version 3.0
+ * that is bundled with this package in the file LICENSE.md
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/license/osl-3-0-php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to support@qloapps.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to a newer
+ * versions in the future. If you wish to customize this module for your needs
+ * please refer to https://store.webkul.com/customisation-guidelines for more information.
+ *
+ * @author Webkul IN
+ * @copyright Since 2010 Webkul
+ * @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+ */
+
+class HotelInquiry extends ObjectModel
+{
+    const STATUS_NEW = 'new';
+    const STATUS_REVIEW = 'review';
+    const STATUS_PENDING = 'awaiting_guest';
+    const STATUS_CONFIRMED = 'confirmed';
+    const STATUS_DECLINED = 'declined';
+
+    const STAGE_INBOX = 'inbox';
+    const STAGE_QUALIFYING = 'qualifying';
+    const STAGE_AWAITING = 'awaiting';
+    const STAGE_SCHEDULED = 'scheduled';
+    const STAGE_ARCHIVED = 'archived';
+
+    /** @var string */
+    public $reference;
+    /** @var string */
+    public $subject;
+    /** @var string */
+    public $status;
+    /** @var string */
+    public $stage;
+    /** @var int */
+    public $assigned_to;
+    /** @var string */
+    public $requester_name;
+    /** @var string */
+    public $requester_email;
+    /** @var string */
+    public $requester_phone;
+    /** @var string */
+    public $check_in;
+    /** @var string */
+    public $check_out;
+    /** @var string */
+    public $resource_request;
+    /** @var string */
+    public $internal_notes;
+    /** @var string */
+    public $reminder_at;
+    /** @var string */
+    public $last_note_at;
+    /** @var string */
+    public $date_add;
+    /** @var string */
+    public $date_upd;
+
+    public static $definition = array(
+        'table' => 'htl_inquiry',
+        'primary' => 'id_inquiry',
+        'fields' => array(
+            'reference' => array('type' => self::TYPE_STRING, 'validate' => 'isString', 'required' => true, 'size' => 32),
+            'subject' => array('type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'required' => true, 'size' => 255),
+            'status' => array('type' => self::TYPE_STRING, 'validate' => 'isString', 'required' => true, 'size' => 32),
+            'stage' => array('type' => self::TYPE_STRING, 'validate' => 'isString', 'required' => true, 'size' => 32),
+            'assigned_to' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId'),
+            'requester_name' => array('type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 255),
+            'requester_email' => array('type' => self::TYPE_STRING, 'validate' => 'isEmail', 'size' => 255),
+            'requester_phone' => array('type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 64),
+            'check_in' => array('type' => self::TYPE_DATE, 'validate' => 'isDateFormat'),
+            'check_out' => array('type' => self::TYPE_DATE, 'validate' => 'isDateFormat'),
+            'resource_request' => array('type' => self::TYPE_HTML, 'validate' => 'isCleanHtml'),
+            'internal_notes' => array('type' => self::TYPE_HTML, 'validate' => 'isCleanHtml'),
+            'reminder_at' => array('type' => self::TYPE_DATE, 'validate' => 'isDateFormat'),
+            'last_note_at' => array('type' => self::TYPE_DATE, 'validate' => 'isDateFormat'),
+            'date_add' => array('type' => self::TYPE_DATE, 'validate' => 'isDate'),
+            'date_upd' => array('type' => self::TYPE_DATE, 'validate' => 'isDate'),
+        ),
+    );
+
+    public function add($autodate = true, $null_values = false)
+    {
+        if (empty($this->reference)) {
+            $this->reference = self::generateReference();
+        }
+        if (empty($this->status)) {
+            $this->status = self::STATUS_NEW;
+        }
+        if (empty($this->stage)) {
+            $this->stage = self::STAGE_INBOX;
+        }
+        $this->date_add = date('Y-m-d H:i:s');
+        $this->date_upd = $this->date_add;
+
+        return parent::add($autodate, $null_values);
+    }
+
+    public function update($null_values = false)
+    {
+        $this->date_upd = date('Y-m-d H:i:s');
+        return parent::update($null_values);
+    }
+
+    public static function getStageDefinitions()
+    {
+        $module = Module::getInstanceByName('hotelreservationsystem');
+        return array(
+            self::STAGE_INBOX => array(
+                'label' => $module->l('Inbox', 'HotelInquiry'),
+                'default_status' => self::STATUS_NEW,
+            ),
+            self::STAGE_QUALIFYING => array(
+                'label' => $module->l('Qualifying', 'HotelInquiry'),
+                'default_status' => self::STATUS_REVIEW,
+            ),
+            self::STAGE_AWAITING => array(
+                'label' => $module->l('Awaiting reply', 'HotelInquiry'),
+                'default_status' => self::STATUS_PENDING,
+            ),
+            self::STAGE_SCHEDULED => array(
+                'label' => $module->l('Scheduled', 'HotelInquiry'),
+                'default_status' => self::STATUS_CONFIRMED,
+            ),
+            self::STAGE_ARCHIVED => array(
+                'label' => $module->l('Archived', 'HotelInquiry'),
+                'default_status' => self::STATUS_DECLINED,
+            ),
+        );
+    }
+
+    public static function getStatusDefinitions()
+    {
+        $module = Module::getInstanceByName('hotelreservationsystem');
+        return array(
+            self::STATUS_NEW => $module->l('New', 'HotelInquiry'),
+            self::STATUS_REVIEW => $module->l('Under review', 'HotelInquiry'),
+            self::STATUS_PENDING => $module->l('Awaiting guest', 'HotelInquiry'),
+            self::STATUS_CONFIRMED => $module->l('Confirmed', 'HotelInquiry'),
+            self::STATUS_DECLINED => $module->l('Declined', 'HotelInquiry'),
+        );
+    }
+
+    public static function generateReference()
+    {
+        $prefix = 'INQ';
+        $sequence = str_pad((string) mt_rand(0, 999999), 6, '0', STR_PAD_LEFT);
+        return $prefix.'-'.date('ymd').'-'.$sequence;
+    }
+
+    public static function getBoardDataset(?array $stageKeys = null)
+    {
+        if ($stageKeys === null) {
+            $stageKeys = array_keys(self::getStageDefinitions());
+        }
+
+        $dataset = array();
+        foreach ($stageKeys as $stage) {
+            $dataset[$stage] = array();
+        }
+
+        $query = new DbQuery();
+        $query->select('*');
+        $query->from('htl_inquiry');
+        if (!empty($stageKeys)) {
+            $escapedStages = array();
+            foreach ($stageKeys as $stageKey) {
+                $escapedStages[] = '\''.pSQL($stageKey).'\'';
+            }
+            $query->where('`stage` IN ('.implode(', ', $escapedStages).')');
+        }
+        $query->orderBy('`date_add` DESC');
+
+        $rows = Db::getInstance()->executeS($query);
+        if (!$rows) {
+            return $dataset;
+        }
+
+        foreach ($rows as $row) {
+            $row['id_inquiry'] = (int) $row['id_inquiry'];
+            $row['assigned_to'] = $row['assigned_to'] ? (int) $row['assigned_to'] : null;
+            if (!isset($dataset[$row['stage']])) {
+                $dataset[$row['stage']] = array();
+            }
+            $dataset[$row['stage']][] = $row;
+        }
+
+        return $dataset;
+    }
+
+    public static function updateStage($idInquiry, $stage, $status = null, $assignedTo = null)
+    {
+        if (!in_array($stage, array_keys(self::getStageDefinitions()), true)) {
+            return false;
+        }
+
+        $data = array(
+            'stage' => pSQL($stage),
+            'date_upd' => date('Y-m-d H:i:s'),
+        );
+
+        if ($status !== null) {
+            $data['status'] = pSQL($status);
+        } else {
+            $definitions = self::getStageDefinitions();
+            if (isset($definitions[$stage]['default_status'])) {
+                $data['status'] = pSQL($definitions[$stage]['default_status']);
+            }
+        }
+
+        if ($assignedTo !== null) {
+            $data['assigned_to'] = (int) $assignedTo ?: null;
+        }
+
+        return Db::getInstance()->update('htl_inquiry', $data, 'id_inquiry='.(int) $idInquiry);
+    }
+
+    public static function scheduleReminder($idInquiry, $dateTime)
+    {
+        $value = $dateTime ? date('Y-m-d H:i:s', strtotime($dateTime)) : null;
+        return Db::getInstance()->update(
+            'htl_inquiry',
+            array(
+                'reminder_at' => $value ? pSQL($value) : null,
+                'date_upd' => date('Y-m-d H:i:s'),
+            ),
+            'id_inquiry='.(int) $idInquiry
+        );
+    }
+
+    public static function touchNoteTimestamp($idInquiry)
+    {
+        return Db::getInstance()->update(
+            'htl_inquiry',
+            array(
+                'last_note_at' => date('Y-m-d H:i:s'),
+                'date_upd' => date('Y-m-d H:i:s'),
+            ),
+            'id_inquiry='.(int) $idInquiry
+        );
+    }
+
+    public static function findById($idInquiry)
+    {
+        $query = new DbQuery();
+        $query->select('*');
+        $query->from('htl_inquiry');
+        $query->where('id_inquiry='.(int) $idInquiry);
+
+        return Db::getInstance()->getRow($query);
+    }
+}

--- a/modules/hotelreservationsystem/classes/HotelInquiryNote.php
+++ b/modules/hotelreservationsystem/classes/HotelInquiryNote.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License version 3.0
+ * that is bundled with this package in the file LICENSE.md
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/license/osl-3-0-php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to support@qloapps.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to a newer
+ * versions in the future. If you wish to customize this module for your needs
+ * please refer to https://store.webkul.com/customisation-guidelines for more information.
+ *
+ * @author Webkul IN
+ * @copyright Since 2010 Webkul
+ * @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+ */
+
+class HotelInquiryNote extends ObjectModel
+{
+    /** @var int */
+    public $id_inquiry;
+    /** @var int */
+    public $id_employee;
+    /** @var string */
+    public $note;
+    /** @var bool */
+    public $is_mail;
+    /** @var string */
+    public $date_add;
+
+    public static $definition = array(
+        'table' => 'htl_inquiry_note',
+        'primary' => 'id_inquiry_note',
+        'fields' => array(
+            'id_inquiry' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
+            'id_employee' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId'),
+            'note' => array('type' => self::TYPE_HTML, 'validate' => 'isCleanHtml', 'required' => true),
+            'is_mail' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => true),
+            'date_add' => array('type' => self::TYPE_DATE, 'validate' => 'isDate'),
+        ),
+    );
+
+    public function add($autodate = true, $null_values = false)
+    {
+        $this->date_add = date('Y-m-d H:i:s');
+        $this->is_mail = (int) $this->is_mail;
+        return parent::add($autodate, $null_values);
+    }
+
+    public static function getInquiryNotes($idInquiry)
+    {
+        $query = new DbQuery();
+        $query->select('*');
+        $query->from('htl_inquiry_note');
+        $query->where('id_inquiry='.(int) $idInquiry);
+        $query->orderBy('date_add DESC');
+
+        $notes = Db::getInstance()->executeS($query);
+        if (!$notes) {
+            return array();
+        }
+
+        foreach ($notes as &$note) {
+            $note['id_inquiry_note'] = (int) $note['id_inquiry_note'];
+            $note['id_inquiry'] = (int) $note['id_inquiry'];
+            $note['id_employee'] = (int) $note['id_employee'];
+            $note['is_mail'] = (int) $note['is_mail'];
+        }
+
+        return $notes;
+    }
+
+    public static function addNote($idInquiry, $content, $idEmployee = null, $isMail = false)
+    {
+        $note = new self();
+        $note->id_inquiry = (int) $idInquiry;
+        $note->note = $content;
+        $note->id_employee = $idEmployee ? (int) $idEmployee : null;
+        $note->is_mail = (bool) $isMail;
+
+        if ($note->add()) {
+            HotelInquiry::touchNoteTimestamp($idInquiry);
+            return $note;
+        }
+
+        return false;
+    }
+}

--- a/modules/hotelreservationsystem/classes/HotelReservationSystemDb.php
+++ b/modules/hotelreservationsystem/classes/HotelReservationSystemDb.php
@@ -220,6 +220,41 @@ class HotelReservationSystemDb
                 PRIMARY KEY (`id_booking_demand`, `id_tax`)
             ) ENGINE="._MYSQL_ENGINE_." DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;",
 
+            "CREATE TABLE IF NOT EXISTS `"._DB_PREFIX_."htl_inquiry` (
+                `id_inquiry` INT(11) NOT NULL AUTO_INCREMENT,
+                `reference` VARCHAR(32) NOT NULL,
+                `subject` VARCHAR(255) NOT NULL,
+                `status` VARCHAR(32) NOT NULL,
+                `stage` VARCHAR(32) NOT NULL,
+                `assigned_to` INT(11) DEFAULT NULL,
+                `requester_name` VARCHAR(255) DEFAULT NULL,
+                `requester_email` VARCHAR(255) DEFAULT NULL,
+                `requester_phone` VARCHAR(64) DEFAULT NULL,
+                `check_in` DATE DEFAULT NULL,
+                `check_out` DATE DEFAULT NULL,
+                `resource_request` TEXT,
+                `internal_notes` LONGTEXT,
+                `reminder_at` DATETIME DEFAULT NULL,
+                `last_note_at` DATETIME DEFAULT NULL,
+                `date_add` DATETIME NOT NULL,
+                `date_upd` DATETIME NOT NULL,
+                PRIMARY KEY (`id_inquiry`),
+                INDEX (`stage`),
+                INDEX (`status`),
+                INDEX (`assigned_to`)
+            ) ENGINE="._MYSQL_ENGINE_." DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;",
+
+            "CREATE TABLE IF NOT EXISTS `"._DB_PREFIX_."htl_inquiry_note` (
+                `id_inquiry_note` INT(11) NOT NULL AUTO_INCREMENT,
+                `id_inquiry` INT(11) NOT NULL,
+                `id_employee` INT(11) DEFAULT NULL,
+                `note` TEXT NOT NULL,
+                `is_mail` TINYINT(1) NOT NULL DEFAULT '0',
+                `date_add` DATETIME NOT NULL,
+                PRIMARY KEY (`id_inquiry_note`),
+                INDEX (`id_inquiry`)
+            ) ENGINE="._MYSQL_ENGINE_." DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;",
+
             "CREATE TABLE IF NOT EXISTS `"._DB_PREFIX_."htl_room_status` (
                 `id` int(11) NOT NULL AUTO_INCREMENT,
                 `status` text NOT NULL,
@@ -615,7 +650,9 @@ class HotelReservationSystemDb
             `'._DB_PREFIX_.'htl_room_type_bed_type`,
             `'._DB_PREFIX_.'htl_access`,
             `'._DB_PREFIX_.'htl_settings_link`,
-            `'._DB_PREFIX_.'htl_settings_link_lang`'
+            `'._DB_PREFIX_.'htl_settings_link_lang`,
+            `'._DB_PREFIX_.'htl_inquiry`,
+            `'._DB_PREFIX_.'htl_inquiry_note`'
         );
     }
 }

--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelInquiriesController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelInquiriesController.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License version 3.0
+ * that is bundled with this package in the file LICENSE.md
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/license/osl-3-0-php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to support@qloapps.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to a newer
+ * versions in the future. If you wish to customize this module for your needs
+ * please refer to https://store.webkul.com/customisation-guidelines for more information.
+ *
+ * @author Webkul IN
+ * @copyright Since 2010 Webkul
+ * @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+ */
+
+class AdminHotelInquiriesController extends ModuleAdminController
+{
+    protected $boardEmployees = array();
+    protected $statusDefinitions = array();
+    protected $stageDefinitions = array();
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        parent::__construct();
+    }
+
+    public function initContent()
+    {
+        parent::initContent();
+
+        $this->stageDefinitions = HotelInquiry::getStageDefinitions();
+        $this->statusDefinitions = HotelInquiry::getStatusDefinitions();
+        $this->boardEmployees = $this->getEmployeesForBoard();
+        $dataset = HotelInquiry::getBoardDataset(array_keys($this->stageDefinitions));
+
+        $this->context->smarty->assign(array(
+            'stage_definitions' => $this->stageDefinitions,
+            'status_definitions' => $this->statusDefinitions,
+            'inquiry_dataset' => $dataset,
+            'board_employees' => $this->boardEmployees,
+        ));
+
+        $this->setTemplate('inquiries/kanban.tpl');
+    }
+
+    public function setMedia()
+    {
+        parent::setMedia();
+        $this->addJquery();
+        $this->addJqueryUI('ui.sortable');
+        $this->addJqueryUI('ui.draggable');
+        $this->addJqueryUI('ui.droppable');
+        $this->addJS($this->module->getPathUri().'views/js/admin/inquiries_board.js');
+        $this->addCSS($this->module->getPathUri().'views/css/admin/inquiries_board.css');
+
+        Media::addJsDef(array(
+            'hotelInquiryBoardConfig' => array(
+                'ajaxUrl' => $this->context->link->getAdminLink('AdminHotelInquiries'),
+                'messages' => array(
+                    'createSuccess' => $this->l('Inquiry created successfully.'),
+                    'updateError' => $this->l('Unable to update the inquiry. Please try again.'),
+                    'notePlaceholder' => $this->l('Add a note that will be logged for the team.', null, true),
+                    'mailNotePlaceholder' => $this->l('Add a note and notify the guest via email.', null, true),
+                    'reminderSaved' => $this->l('Reminder updated.'),
+                    'reminderCleared' => $this->l('Reminder cleared.'),
+                    'reminderPrompt' => $this->l('Enter reminder timestamp (YYYY-MM-DD HH:MM) or leave blank to clear.'),
+                    'noteSaved' => $this->l('Note saved.'),
+                    'assignmentSaved' => $this->l('Assignment updated.'),
+                    'noNotes' => $this->l('No notes yet.'),
+                ),
+                'stageStatuses' => array_map(function ($definition) {
+                    return isset($definition['default_status']) ? $definition['default_status'] : null;
+                }, $this->stageDefinitions),
+            ),
+        ));
+    }
+
+    public function ajaxProcessCreateInquiry()
+    {
+        $response = array('success' => false);
+        if ($this->tabAccess['add'] != '1') {
+            $response['message'] = $this->l('You do not have permission to create inquiries.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        $subject = Tools::getValue('subject');
+        if (!$subject) {
+            $response['message'] = $this->l('Subject is required.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        $inquiry = new HotelInquiry();
+        $inquiry->subject = $subject;
+        $inquiry->requester_name = Tools::getValue('requester_name');
+        $inquiry->requester_email = Tools::getValue('requester_email');
+        $inquiry->requester_phone = Tools::getValue('requester_phone');
+        $inquiry->resource_request = Tools::getValue('resource_request');
+        $inquiry->internal_notes = Tools::getValue('internal_notes');
+        $inquiry->check_in = $this->normalizeDate(Tools::getValue('check_in'));
+        $inquiry->check_out = $this->normalizeDate(Tools::getValue('check_out'));
+        $assignedValue = Tools::getValue('assigned_to');
+        $inquiry->assigned_to = $assignedValue === '' ? null : (int) $assignedValue;
+
+        if ($inquiry->add()) {
+            $row = HotelInquiry::findById($inquiry->id);
+            $response['success'] = true;
+            $response['inquiry'] = $row;
+            $response['card_html'] = $this->renderInquiryCard($row);
+        } else {
+            $response['message'] = $this->l('Could not create inquiry. Please review the data.');
+        }
+
+        return $this->ajaxDie(json_encode($response));
+    }
+
+    public function ajaxProcessUpdateInquiryStage()
+    {
+        $response = array('success' => false);
+        if ($this->tabAccess['edit'] != '1') {
+            $response['message'] = $this->l('You do not have permission to update inquiries.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        $idInquiry = (int) Tools::getValue('id_inquiry');
+        $stage = Tools::getValue('stage');
+        $assigned = Tools::getValue('assigned_to');
+
+        if (!$idInquiry || !$stage) {
+            $response['message'] = $this->l('Missing inquiry information.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        $statusOverride = Tools::getValue('status');
+        if ($statusOverride === '') {
+            $statusOverride = null;
+        }
+
+        if (HotelInquiry::updateStage($idInquiry, $stage, $statusOverride, $assigned === '' ? null : (int) $assigned)) {
+            $row = HotelInquiry::findById($idInquiry);
+            $response['success'] = true;
+            $response['inquiry'] = $row;
+            $response['card_html'] = $this->renderInquiryCard($row);
+        } else {
+            $response['message'] = $this->l('Unable to update the inquiry stage.');
+        }
+
+        return $this->ajaxDie(json_encode($response));
+    }
+
+    public function ajaxProcessUpdateInquiryAssignment()
+    {
+        $response = array('success' => false);
+        if ($this->tabAccess['edit'] != '1') {
+            $response['message'] = $this->l('You do not have permission to update inquiries.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        $idInquiry = (int) Tools::getValue('id_inquiry');
+        $assigned = Tools::getValue('assigned_to');
+        if (!$idInquiry) {
+            $response['message'] = $this->l('Missing inquiry information.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        if (!$row = HotelInquiry::findById($idInquiry)) {
+            $response['message'] = $this->l('Inquiry not found.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        if (HotelInquiry::updateStage($idInquiry, $row['stage'], null, $assigned === '' ? null : (int) $assigned)) {
+            $row = HotelInquiry::findById($idInquiry);
+            $response['success'] = true;
+            $response['inquiry'] = $row;
+            $response['card_html'] = $this->renderInquiryCard($row);
+        } else {
+            $response['message'] = $this->l('Unable to update assignment.');
+        }
+
+        return $this->ajaxDie(json_encode($response));
+    }
+
+    public function ajaxProcessAddInquiryNote()
+    {
+        $response = array('success' => false);
+        if ($this->tabAccess['edit'] != '1') {
+            $response['message'] = $this->l('You do not have permission to add notes.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        $idInquiry = (int) Tools::getValue('id_inquiry');
+        $note = Tools::getValue('note');
+        $isMail = (bool) Tools::getValue('is_mail');
+
+        if (!$idInquiry || !$note) {
+            $response['message'] = $this->l('A note body is required.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        if ($noteObject = HotelInquiryNote::addNote($idInquiry, $note, $this->context->employee->id, $isMail)) {
+            $response['success'] = true;
+            $response['note'] = $noteObject;
+            $response['notes'] = HotelInquiryNote::getInquiryNotes($idInquiry);
+        } else {
+            $response['message'] = $this->l('Unable to save the note.');
+        }
+
+        return $this->ajaxDie(json_encode($response));
+    }
+
+    public function ajaxProcessScheduleInquiryReminder()
+    {
+        $response = array('success' => false);
+        if ($this->tabAccess['edit'] != '1') {
+            $response['message'] = $this->l('You do not have permission to schedule reminders.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        $idInquiry = (int) Tools::getValue('id_inquiry');
+        $reminderAt = Tools::getValue('reminder_at');
+        if (!$idInquiry) {
+            $response['message'] = $this->l('Missing inquiry information.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        if (HotelInquiry::scheduleReminder($idInquiry, $reminderAt)) {
+            $response['success'] = true;
+            $response['reminder_at'] = $reminderAt ? date('Y-m-d H:i:s', strtotime($reminderAt)) : null;
+        } else {
+            $response['message'] = $this->l('Unable to schedule the reminder.');
+        }
+
+        return $this->ajaxDie(json_encode($response));
+    }
+
+    public function ajaxProcessGetInquiryDetails()
+    {
+        $idInquiry = (int) Tools::getValue('id_inquiry');
+        $response = array('success' => false);
+        if (!$idInquiry) {
+            $response['message'] = $this->l('Missing inquiry information.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        if ($row = HotelInquiry::findById($idInquiry)) {
+            $response['success'] = true;
+            $response['inquiry'] = $row;
+            $response['notes'] = HotelInquiryNote::getInquiryNotes($idInquiry);
+            $response['card_html'] = $this->renderInquiryCard($row);
+        } else {
+            $response['message'] = $this->l('Inquiry not found.');
+        }
+
+        return $this->ajaxDie(json_encode($response));
+    }
+
+    protected function getEmployeesForBoard()
+    {
+        $employees = Employee::getEmployees(false);
+        $list = array();
+        foreach ($employees as $employee) {
+            $list[] = array(
+                'id_employee' => (int) $employee['id_employee'],
+                'name' => trim($employee['firstname'].' '.$employee['lastname']),
+            );
+        }
+
+        return $list;
+    }
+
+    protected function normalizeDate($value)
+    {
+        if (!$value) {
+            return null;
+        }
+        $timestamp = strtotime($value);
+        if (!$timestamp) {
+            return null;
+        }
+
+        return date('Y-m-d', $timestamp);
+    }
+
+    protected function renderInquiryCard($row)
+    {
+        if (!$this->stageDefinitions) {
+            $this->stageDefinitions = HotelInquiry::getStageDefinitions();
+        }
+        if (!$this->statusDefinitions) {
+            $this->statusDefinitions = HotelInquiry::getStatusDefinitions();
+        }
+        if (!$this->boardEmployees) {
+            $this->boardEmployees = $this->getEmployeesForBoard();
+        }
+
+        $this->context->smarty->assign(array(
+            'inquiry' => $row,
+            'stage_definitions' => $this->stageDefinitions,
+            'status_definitions' => $this->statusDefinitions,
+            'board_employees' => $this->boardEmployees,
+        ));
+
+        return $this->context->smarty->fetch($this->module->getLocalPath().'views/templates/admin/inquiries/_partials/card.tpl');
+    }
+}

--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
@@ -955,9 +955,197 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
         die(Tools::jsonEncode($response));
     }
 
+    public function ajaxProcessValidateTimelineMove()
+    {
+        $this->ajaxDie(json_encode($this->handleTimelineMove(false)));
+    }
+
+    public function ajaxProcessPerformTimelineMove()
+    {
+        $this->ajaxDie(json_encode($this->handleTimelineMove(true)));
+    }
+
+    public function ajaxProcessLookupAvailability()
+    {
+        $response = array('success' => false);
+        $idHotel = (int) Tools::getValue('id_hotel');
+        $idRoomType = (int) Tools::getValue('id_room_type');
+        $dateFrom = Tools::getValue('date_from');
+        $dateTo = Tools::getValue('date_to');
+
+        $fromDate = DateTime::createFromFormat('Y-m-d', $dateFrom ?: '');
+        $toDate = DateTime::createFromFormat('Y-m-d', $dateTo ?: '');
+
+        if (!$idHotel || !$idRoomType || !$fromDate || !$toDate) {
+            $response['message'] = $this->l('Invalid availability lookup request.');
+            return $this->ajaxDie(json_encode($response));
+        }
+
+        if ($fromDate >= $toDate) {
+            $toDate = clone $fromDate;
+            $toDate->modify('+1 day');
+        }
+
+        $roomInfoAdapter = new HotelRoomInformation();
+        $fromIso = $fromDate->format('Y-m-d');
+        $toIso = $toDate->format('Y-m-d');
+
+        $response['success'] = true;
+        $response['data'] = array(
+            'available' => $roomInfoAdapter->getRoomTypeAvailableRoomsForDateRange($idHotel, $idRoomType, $fromIso, $toIso),
+            'booked' => $roomInfoAdapter->getRoomTypeBookedRoomsForDateRange($idHotel, $idRoomType, $fromIso, $toIso),
+            'disabled' => $roomInfoAdapter->getRoomTypeDisabledRoomsForDateRange($idHotel, $idRoomType, $fromIso, $toIso),
+        );
+
+        $this->ajaxDie(json_encode($response));
+    }
+
+    protected function handleTimelineMove($perform = false)
+    {
+        $response = array(
+            'success' => false,
+            'can_move' => false,
+            'conflicts' => array(),
+        );
+
+        $idBooking = (int) Tools::getValue('id_htl_booking');
+        $targetRoomId = (int) Tools::getValue('target_room_id');
+        $targetDateFrom = Tools::getValue('target_date_from');
+
+        if (!$idBooking || !$targetRoomId || !$targetDateFrom) {
+            $response['message'] = $this->l('Incomplete move request.');
+            return $response;
+        }
+
+        if (!Validate::isLoadedObject($booking = new HotelBookingDetail($idBooking))) {
+            $response['message'] = $this->l('Booking not found.');
+            return $response;
+        }
+
+        if (!Validate::isLoadedObject($targetRoom = new HotelRoomInformation($targetRoomId))) {
+            $response['message'] = $this->l('Target room not found.');
+            return $response;
+        }
+
+        $evaluation = $this->evaluateTimelineMove($booking, $targetRoom, $targetDateFrom);
+
+        if ($perform && empty($evaluation['conflicts'])) {
+            if ($this->applyTimelineMove($booking, $targetRoom, $evaluation['preview']['date_from'], $evaluation['preview']['date_to'])) {
+                $evaluation['success'] = true;
+                $evaluation['can_move'] = true;
+            } else {
+                $evaluation['success'] = false;
+                $evaluation['message'] = $this->l('Unable to update the booking.');
+            }
+        }
+
+        return $evaluation;
+    }
+
+    protected function evaluateTimelineMove(HotelBookingDetail $booking, HotelRoomInformation $targetRoom, $targetDateFrom)
+    {
+        $result = array(
+            'success' => true,
+            'can_move' => false,
+            'conflicts' => array(),
+            'preview' => array(),
+        );
+
+        $startDate = DateTime::createFromFormat('Y-m-d', $targetDateFrom ?: '');
+        if (!$startDate) {
+            $result['success'] = false;
+            $result['conflicts'][] = $this->l('Invalid target start date.');
+            return $result;
+        }
+
+        $duration = (int) HotelHelper::getNumberOfDays($booking->date_from, $booking->date_to);
+        if ($duration < 1) {
+            $duration = 1;
+        }
+        $endDate = clone $startDate;
+        $endDate->modify('+' . (int) $duration . ' day');
+
+        $fromTime = date('H:i:s', strtotime($booking->date_from));
+        $toTime = date('H:i:s', strtotime($booking->date_to));
+        $newFrom = $startDate->format('Y-m-d') . ' ' . $fromTime;
+        $newTo = $endDate->format('Y-m-d') . ' ' . $toTime;
+
+        $result['preview'] = array(
+            'room_id' => (int) $targetRoom->id,
+            'room_label' => $targetRoom->room_num,
+            'date_from' => $newFrom,
+            'date_to' => $newTo,
+        );
+
+        if ((int) $targetRoom->id_hotel !== (int) $booking->id_hotel) {
+            $result['conflicts'][] = $this->l('Cannot move booking to a different hotel.');
+        }
+
+        if ((int) $targetRoom->id_product !== (int) $booking->id_product) {
+            $result['conflicts'][] = $this->l('Target room belongs to a different room type.');
+        }
+
+        $roomTypeAdapter = new HotelRoomType();
+        if ($roomTypeInfo = $roomTypeAdapter->getRoomTypeInfoByIdProduct($booking->id_product)) {
+            $adults = (int) $booking->adults;
+            $children = (int) $booking->children;
+            $totalGuests = $adults + $children;
+            if (!empty($roomTypeInfo['max_adults']) && $adults > (int) $roomTypeInfo['max_adults']) {
+                $result['conflicts'][] = $this->l('Adult occupancy exceeds the room capacity.');
+            }
+            if (!empty($roomTypeInfo['max_children']) && $children > (int) $roomTypeInfo['max_children']) {
+                $result['conflicts'][] = $this->l('Children occupancy exceeds the room capacity.');
+            }
+            if (!empty($roomTypeInfo['max_guests']) && $totalGuests > (int) $roomTypeInfo['max_guests']) {
+                $result['conflicts'][] = $this->l('Total guests exceed the room capacity.');
+            }
+        }
+
+        $disableSql = 'SELECT `id` FROM `'._DB_PREFIX_.'htl_room_disable_dates` '
+            . 'WHERE `id_room` = '.(int) $targetRoom->id
+            . ' AND `date_from` < \'' . pSQL($newTo) . '\''
+            . ' AND `date_to` > \'' . pSQL($newFrom) . '\'';
+        if (Db::getInstance()->getValue($disableSql)) {
+            $result['conflicts'][] = $this->l('Room is disabled for the selected dates.');
+        }
+
+        $overlapSql = 'SELECT `id` FROM `'._DB_PREFIX_.'htl_booking_detail` '
+            . 'WHERE `id_room` = '.(int) $targetRoom->id
+            . ' AND `id` != '.(int) $booking->id
+            . ' AND `is_cancelled` = 0 AND `is_refunded` = 0'
+            . ' AND `date_from` < \'' . pSQL($newTo) . '\''
+            . ' AND `date_to` > \'' . pSQL($newFrom) . '\'';
+        if (Db::getInstance()->getValue($overlapSql)) {
+            $result['conflicts'][] = $this->l('Room already has a conflicting booking.');
+        }
+
+        if (empty($result['conflicts'])) {
+            $result['can_move'] = true;
+        }
+
+        return $result;
+    }
+
+    protected function applyTimelineMove(HotelBookingDetail $booking, HotelRoomInformation $targetRoom, $newFrom, $newTo)
+    {
+        $booking->id_room = (int) $targetRoom->id;
+        $booking->id_hotel = (int) $targetRoom->id_hotel;
+        $booking->room_num = $targetRoom->room_num;
+        $booking->date_from = $newFrom;
+        $booking->check_in = $newFrom;
+        $booking->date_to = $newTo;
+        $booking->check_out = $newTo;
+        $booking->planned_check_out = $newTo;
+        $booking->date_upd = date('Y-m-d H:i:s');
+
+        return $booking->update();
+    }
+
     public function setMedia()
     {
         parent::setMedia();
+        $this->addJqueryUI('ui.draggable');
+        $this->addJqueryUI('ui.droppable');
         $currency = new Currency((int)Configuration::get('PS_CURRENCY_DEFAULT'));
         $occupancyRequiredForBooking = false;
         if (Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
@@ -1037,6 +1225,12 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
                     'partial' => $this->l('Partially available', null, true),
                     'available' => $this->l('Available', null, true),
                 ),
+            ),
+            'timeline_api_url' => $this->context->link->getAdminLink('AdminHotelRoomsBooking'),
+            'timeline_interactions' => array(
+                'moveSuccess' => $this->l('Booking updated.', null, true),
+                'moveError' => $this->l('Unable to move the booking.', null, true),
+                'moveConfirm' => $this->l('Move booking to %room% starting %from%? (Ends %to%)', null, true),
             ),
         );
         if (Configuration::get('PS_BACKOFFICE_SEARCH_TYPE') == HotelBookingDetail::SEARCH_TYPE_OWS ) {

--- a/modules/hotelreservationsystem/define.php
+++ b/modules/hotelreservationsystem/define.php
@@ -60,3 +60,5 @@ require_once 'classes/ServiceProductOption.php';
 
 require_once 'classes/HotelSettingsLink.php';
 require_once 'classes/HotelBookingDocument.php';
+require_once 'classes/HotelInquiry.php';
+require_once 'classes/HotelInquiryNote.php';

--- a/modules/hotelreservationsystem/hotelreservationsystem.php
+++ b/modules/hotelreservationsystem/hotelreservationsystem.php
@@ -33,7 +33,7 @@ class HotelReservationSystem extends Module
     {
         $this->name = 'hotelreservationsystem';
         $this->tab = 'administration';
-        $this->version = '1.7.0';
+        $this->version = '1.8.0';
         $this->author = 'Webkul';
         $this->need_instance = 0;
         $this->bootstrap = true;
@@ -533,6 +533,7 @@ class HotelReservationSystem extends Module
         $this->installTab('AdminHotelReservationSystemManagement', 'Hotel Reservation System');
         $this->installTab('AdminAddHotel', 'Manage Hotel', 'AdminHotelReservationSystemManagement');
         $this->installTab('AdminHotelRoomsBooking', 'Book Now', 'AdminHotelReservationSystemManagement');
+        $this->installTab('AdminHotelInquiries', 'Inquiries', 'AdminHotelReservationSystemManagement');
         $this->installTab('AdminHotelFeatures', 'Manage Hotel Features', 'AdminHotelReservationSystemManagement');
         $this->installTab('AdminOrderRefundRules', 'Manage Order Refund Rules', 'AdminHotelReservationSystemManagement');
         $this->installTab('AdminOrderRefundRequests', 'Manage Order Refund Requests', 'AdminHotelReservationSystemManagement');

--- a/modules/hotelreservationsystem/upgrade/upgrade-1.8.0.php
+++ b/modules/hotelreservationsystem/upgrade/upgrade-1.8.0.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License version 3.0
+ * that is bundled with this package in the file LICENSE.md
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/license/osl-3-0-php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to support@qloapps.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to a newer
+ * versions in the future. If you wish to customize this module for your needs
+ * please refer to https://store.webkul.com/customisation-guidelines for more information.
+ *
+ * @author Webkul IN
+ * @copyright Since 2010 Webkul
+ * @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_1_8_0(HotelReservationSystem $module)
+{
+    include_once _PS_MODULE_DIR_.'hotelreservationsystem/define.php';
+
+    $db = new HotelReservationSystemDb();
+    if (!$db->createTables()) {
+        return false;
+    }
+
+    // ensure the inquiries tab exists after upgrade
+    $module->installTab('AdminHotelInquiries', 'Inquiries', 'AdminHotelReservationSystemManagement');
+
+    return true;
+}

--- a/modules/hotelreservationsystem/views/css/HotelReservationAdmin.css
+++ b/modules/hotelreservationsystem/views/css/HotelReservationAdmin.css
@@ -831,6 +831,33 @@ body.adminhotelroomsbooking .ui-tooltip {
     opacity: 1;
 }
 
+.timeline-cell.timeline-draggable {
+    cursor: move;
+    border-top: 2px solid #3a87ad;
+}
+
+.timeline-cell.timeline-dragging {
+    opacity: 0.65;
+}
+
+.timeline-cell.timeline-drop-hover {
+    outline: 2px dashed #3a87ad;
+}
+
+.timeline-cell.timeline-drop-processing {
+    background-image: repeating-linear-gradient(45deg, rgba(58,135,173,0.18), rgba(58,135,173,0.18) 10px, rgba(58,135,173,0.05) 10px, rgba(58,135,173,0.05) 20px);
+}
+
+.timeline-drag-helper {
+    padding: 6px 10px;
+    background: #3a87ad;
+    color: #fff;
+    border-radius: 3px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    font-size: 12px;
+    pointer-events: none;
+}
+
 .timeline-legend {
     margin: 15px 0;
     display: flex;

--- a/modules/hotelreservationsystem/views/css/admin/inquiries_board.css
+++ b/modules/hotelreservationsystem/views/css/admin/inquiries_board.css
@@ -1,0 +1,147 @@
+.inquiry-board-panel {
+    min-height: 480px;
+}
+
+#hotel-inquiry-board {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.inquiry-column {
+    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+}
+
+.inquiry-column-header {
+    background: #f5f5f5;
+    border: 1px solid #ddd;
+    padding: 10px;
+    font-weight: 600;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.inquiry-column-body {
+    border: 1px solid #ddd;
+    border-top: none;
+    background: #fff;
+    min-height: 220px;
+    padding: 10px;
+}
+
+.inquiry-card {
+    border: 1px solid #c8d7e1;
+    border-left: 4px solid #3a87ad;
+    background: #fff;
+    margin-bottom: 12px;
+    padding: 10px;
+    cursor: move;
+}
+
+.inquiry-card.dragging {
+    opacity: 0.8;
+}
+
+.inquiry-card-placeholder {
+    border: 2px dashed #3a87ad;
+    height: 80px;
+    margin-bottom: 12px;
+}
+
+.inquiry-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 6px;
+}
+
+.inquiry-card-status {
+    font-size: 12px;
+    color: #666;
+}
+
+.inquiry-card-body {
+    font-size: 13px;
+    color: #333;
+}
+
+.inquiry-card-body .inquiry-card-contact,
+.inquiry-card-body .inquiry-card-dates,
+.inquiry-card-body .inquiry-card-reminder,
+.inquiry-card-body .inquiry-card-noteinfo {
+    margin-top: 4px;
+}
+
+.inquiry-card-body i {
+    color: #7a8b9a;
+    margin-right: 4px;
+}
+
+.inquiry-card-resources {
+    margin-top: 6px;
+    font-style: italic;
+    color: #555;
+}
+
+.inquiry-card-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-top: 8px;
+}
+
+.inquiry-card-footer label {
+    font-size: 11px;
+    display: block;
+    color: #888;
+}
+
+.inquiry-card-actions .btn {
+    padding: 0;
+}
+
+.inquiry-card-actions .btn i {
+    font-size: 14px;
+}
+
+.inquiry-column-body.highlight-drop {
+    background: #f0f8ff;
+}
+
+.inquiry-note-history {
+    max-height: 200px;
+    overflow-y: auto;
+    margin-top: 10px;
+    border-top: 1px solid #eee;
+    padding-top: 10px;
+}
+
+.inquiry-note-history .note-item {
+    margin-bottom: 10px;
+    font-size: 12px;
+}
+
+.inquiry-note-history .note-meta {
+    color: #888;
+    margin-bottom: 4px;
+}
+
+.inquiry-note-history .note-body {
+    white-space: pre-wrap;
+}
+
+@media (max-width: 991px) {
+    .inquiry-column {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+}
+
+@media (max-width: 767px) {
+    .inquiry-column {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+}

--- a/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
+++ b/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
@@ -46,6 +46,9 @@ $(document).ready(function() {
             available: 'Available',
         },
     };
+    var timelineApiUrl = window.timeline_api_url || rooms_booking_url;
+    var timelineInteractionConfig = window.timeline_interactions || {};
+    var activeTimelineDragRequest = null;
     var inquiryMode = ($('.panel-booking-timeline').data('kunstort-core-mode') || '').toLowerCase() === 'inquiry';
 
     if (inquiryMode && timelineLabels.statusLabels) {
@@ -318,6 +321,16 @@ $(document).ready(function() {
         }
     }
 
+    function formatDateIso(ts) {
+        var date = new Date(ts);
+        if (isNaN(date.getTime())) {
+            return '';
+        }
+        var month = ('0' + (date.getMonth() + 1)).slice(-2);
+        var day = ('0' + date.getDate()).slice(-2);
+        return date.getFullYear() + '-' + month + '-' + day;
+    }
+
     function formatDateFromString(value) {
         var ts = normalizeDateInput(value);
         if (ts === null) {
@@ -378,6 +391,7 @@ $(document).ready(function() {
         });
 
         timelineContainer.append(table);
+        activateTimelineDragAndDrop();
     }
 
     function buildTimelineHeader(days) {
@@ -431,7 +445,15 @@ $(document).ready(function() {
                     label: label,
                     sortValue: label.toString().toLowerCase(),
                     periods: [],
+                    roomTypeId: info.id_product || roomType.id_product || null,
+                    hotelId: info.id_hotel || roomType.id_hotel || null,
                 };
+            }
+            if (!roomsMap[id].roomTypeId && (info.id_product || roomType.id_product)) {
+                roomsMap[id].roomTypeId = info.id_product || roomType.id_product;
+            }
+            if (!roomsMap[id].hotelId && (info.id_hotel || roomType.id_hotel)) {
+                roomsMap[id].hotelId = info.id_hotel || roomType.id_hotel;
             }
             return roomsMap[id];
         }
@@ -528,6 +550,8 @@ $(document).ready(function() {
             status: 'available',
             meta: {},
             priority: 1,
+            start: null,
+            end: null,
         };
 
         $.each(room.periods, function(_, period) {
@@ -540,6 +564,8 @@ $(document).ready(function() {
                         status: period.status,
                         meta: period.meta || {},
                         priority: priority,
+                        start: start,
+                        end: end,
                     };
                 }
             }
@@ -574,10 +600,221 @@ $(document).ready(function() {
             var info = resolveStatusForDay(room, ts, range);
             var cell = $('<div class="timeline-cell"/>').addClass('status-' + info.status);
             cell.attr('title', buildTooltip(info, ts));
+            cell.data('dayTs', ts);
+            cell.data('dateIso', formatDateIso(ts));
+            cell.data('roomId', room.id);
+            cell.data('roomTypeId', room.roomTypeId || null);
+            cell.data('hotelId', room.hotelId || null);
+            cell.data('meta', info.meta || {});
+            cell.data('range', { start: info.start, end: info.end });
+            if (info.meta && info.meta.id_htl_booking) {
+                cell.attr('data-booking-id', info.meta.id_htl_booking);
+            }
+            if (info.start !== null && ts === info.start && info.meta && info.meta.id_htl_booking) {
+                cell.addClass('timeline-booking-start');
+            }
             grid.append(cell);
         });
         row.append(grid);
         return row;
+    }
+
+    function activateTimelineDragAndDrop() {
+        if (!timelineContainer.length || typeof $.fn.draggable === 'undefined' || typeof $.fn.droppable === 'undefined') {
+            return;
+        }
+
+        timelineContainer.find('.timeline-cell.timeline-draggable').each(function () {
+            if ($(this).data('uiDraggable')) {
+                $(this).draggable('destroy');
+            }
+        }).removeClass('timeline-draggable timeline-dragging');
+
+        timelineContainer.find('.timeline-cell').each(function () {
+            if ($(this).data('uiDroppable')) {
+                $(this).droppable('destroy');
+            }
+        }).removeClass('timeline-drop-hover timeline-drop-processing');
+
+        timelineContainer.find('.timeline-cell.timeline-booking-start').each(function () {
+            makeTimelineCellDraggable($(this));
+        });
+
+        timelineContainer.find('.timeline-cell').each(function () {
+            makeTimelineCellDroppable($(this));
+        });
+    }
+
+    function makeTimelineCellDraggable(cell) {
+        var meta = cell.data('meta') || {};
+        if (!meta.id_htl_booking) {
+            return;
+        }
+        cell.addClass('timeline-draggable');
+        cell.draggable({
+            helper: function () {
+                var label = meta.room_type_name || meta.alloted_cust_name || ('#' + meta.id_htl_booking);
+                return $('<div class="timeline-drag-helper"/>').text(label);
+            },
+            appendTo: 'body',
+            zIndex: 9999,
+            revert: 'invalid',
+            start: function () {
+                cell.addClass('timeline-dragging');
+            },
+            stop: function () {
+                cell.removeClass('timeline-dragging');
+            }
+        });
+    }
+
+    function makeTimelineCellDroppable(cell) {
+        if (!cell.data('roomId')) {
+            return;
+        }
+        cell.droppable({
+            accept: function (draggable) {
+                if (!draggable.hasClass('timeline-draggable')) {
+                    return false;
+                }
+                if (!cell.hasClass('status-available') && !cell.hasClass('status-partial')) {
+                    return false;
+                }
+                return true;
+            },
+            hoverClass: 'timeline-drop-hover',
+            tolerance: 'pointer',
+            drop: function (event, ui) {
+                var source = ui.draggable;
+                handleTimelineDrop(cell, source);
+            }
+        });
+    }
+
+    function handleTimelineDrop(targetCell, sourceCell) {
+        var sourceMeta = sourceCell.data('meta') || {};
+        var bookingId = sourceMeta.id_htl_booking;
+        if (!bookingId) {
+            queueTimelineRefresh();
+            return;
+        }
+        var targetRoomId = parseInt(targetCell.data('roomId'), 10);
+        var targetDate = targetCell.data('dateIso');
+        if (!targetRoomId || !targetDate) {
+            queueTimelineRefresh();
+            return;
+        }
+        var range = sourceCell.data('range') || {};
+        var originalRoomId = parseInt(sourceCell.data('roomId'), 10);
+        var originalStartIso = range.start ? formatDateIso(range.start) : null;
+        if (targetRoomId === originalRoomId && originalStartIso === targetDate) {
+            queueTimelineRefresh();
+            return;
+        }
+
+        var payload = {
+            ajax: true,
+            action: 'validateTimelineMove',
+            id_htl_booking: bookingId,
+            target_room_id: targetRoomId,
+            target_date_from: targetDate
+        };
+
+        if (activeTimelineDragRequest) {
+            activeTimelineDragRequest.abort();
+        }
+
+        targetCell.addClass('timeline-drop-processing');
+        activeTimelineDragRequest = $.ajax({
+            url: timelineApiUrl,
+            method: 'POST',
+            dataType: 'json',
+            data: payload
+        }).done(function (response) {
+            if (response && response.can_move) {
+                var confirmMessage = timelineInteractionConfig.moveConfirm || null;
+                if (confirmMessage) {
+                    var preview = response.preview || {};
+                    confirmMessage = confirmMessage.replace('%room%', preview.room_label || targetCell.closest('.room-row').find('.room-label').text());
+                    confirmMessage = confirmMessage.replace('%from%', preview.date_from || payload.target_date_from);
+                    confirmMessage = confirmMessage.replace('%to%', preview.date_to || '');
+                    if (!window.confirm(confirmMessage)) {
+                        queueTimelineRefresh();
+                        return;
+                    }
+                }
+                performTimelineMove(payload);
+            } else {
+                showTimelineConflicts(response && response.conflicts ? response.conflicts : []);
+                queueTimelineRefresh();
+            }
+        }).fail(function () {
+            notifyTimelineError(timelineInteractionConfig.moveError || timelineLabels.error || 'Unable to move booking.');
+            queueTimelineRefresh();
+        }).always(function () {
+            targetCell.removeClass('timeline-drop-processing');
+            activeTimelineDragRequest = null;
+        });
+    }
+
+    function performTimelineMove(basePayload) {
+        var payload = $.extend({}, basePayload, {
+            action: 'performTimelineMove'
+        });
+
+        if (activeTimelineDragRequest) {
+            activeTimelineDragRequest.abort();
+        }
+
+        activeTimelineDragRequest = $.ajax({
+            url: timelineApiUrl,
+            method: 'POST',
+            dataType: 'json',
+            data: payload
+        }).done(function (response) {
+            if (response && response.success) {
+                notifyTimelineSuccess(timelineInteractionConfig.moveSuccess || 'Booking updated.');
+                queueTimelineRefresh();
+            } else {
+                notifyTimelineError(response && response.message ? response.message : (timelineInteractionConfig.moveError || timelineLabels.error || 'Unable to move booking.'));
+                queueTimelineRefresh();
+            }
+        }).fail(function () {
+        notifyTimelineError(timelineInteractionConfig.moveError || timelineLabels.error || 'Unable to move booking.');
+            queueTimelineRefresh();
+        }).always(function () {
+            activeTimelineDragRequest = null;
+        });
+    }
+
+    function showTimelineConflicts(conflicts) {
+        if (!conflicts || !conflicts.length) {
+            notifyTimelineError(timelineInteractionConfig.moveError || timelineLabels.error || 'Unable to move booking.');
+            return;
+        }
+        notifyTimelineError(conflicts.join('\n'));
+    }
+
+    function notifyTimelineSuccess(message) {
+        if (!message) {
+            return;
+        }
+        if (typeof showSuccessMessage === 'function') {
+            showSuccessMessage(message);
+        } else {
+            alert(message);
+        }
+    }
+
+    function notifyTimelineError(message) {
+        if (!message) {
+            return;
+        }
+        if (typeof showErrorMessage === 'function') {
+            showErrorMessage(message);
+        } else {
+            alert(message);
+        }
     }
     function ensureTimeline(forceReload) {
         if (!timelineContainer.length) {

--- a/modules/hotelreservationsystem/views/js/admin/inquiries_board.js
+++ b/modules/hotelreservationsystem/views/js/admin/inquiries_board.js
@@ -1,0 +1,325 @@
+(function ($) {
+    'use strict';
+
+    function notifySuccess(message) {
+        if (!message) {
+            return;
+        }
+        if (typeof window.showSuccessMessage === 'function') {
+            window.showSuccessMessage(message);
+        } else {
+            $.growl ? $.growl.notice({ title: '', message: message }) : alert(message);
+        }
+    }
+
+    function notifyError(message) {
+        if (!message) {
+            return;
+        }
+        if (typeof window.showErrorMessage === 'function') {
+            window.showErrorMessage(message);
+        } else {
+            $.growl ? $.growl.error({ title: '', message: message }) : alert(message);
+        }
+    }
+
+    $(function () {
+        var config = window.hotelInquiryBoardConfig || {};
+        var ajaxUrl = config.ajaxUrl || '';
+        var stageStatuses = config.stageStatuses || {};
+        var $board = $('#hotel-inquiry-board');
+        var $createModal = $('#inquiry-create-modal');
+        var $noteModal = $('#inquiry-note-modal');
+        var $noteForm = $('#inquiry-note-form');
+        var $noteHistory = $noteModal.find('.inquiry-note-history');
+
+        function updateCounts() {
+            $board.find('.inquiry-column-body').each(function () {
+                var stage = $(this).data('stage-list');
+                var count = $(this).find('.inquiry-card').length;
+                $board.find('[data-stage-count="' + stage + '"]').text(count);
+            });
+        }
+
+        function bindCard($card) {
+            $card.find('.inquiry-assignee').off('change').on('change', function () {
+                var assignedTo = $(this).val();
+                var id = $card.data('inquiry-id');
+                var stage = $card.closest('.inquiry-column').data('stage');
+                $.ajax({
+                    url: ajaxUrl,
+                    method: 'POST',
+                    dataType: 'json',
+                    data: {
+                        ajax: true,
+                        action: 'updateInquiryAssignment',
+                        id_inquiry: id,
+                        assigned_to: assignedTo,
+                        stage: stage
+                    }
+                }).done(function (response) {
+                    if (response && response.success && response.card_html) {
+                        replaceCard($card, response.card_html);
+                        notifySuccess(config.messages && config.messages.assignmentSaved);
+                    } else {
+                        notifyError(response && response.message ? response.message : (config.messages && config.messages.updateError));
+                    }
+                }).fail(function () {
+                    notifyError(config.messages && config.messages.updateError);
+                });
+            });
+
+            $card.find('[data-role="notes"]').off('click').on('click', function (event) {
+                event.preventDefault();
+                openNotesModal($card.data('inquiry-id'));
+            });
+
+            $card.find('[data-role="reminder"]').off('click').on('click', function (event) {
+                event.preventDefault();
+                promptReminder($card);
+            });
+        }
+
+        function replaceCard($oldCard, html) {
+            var $newCard = $(html);
+            $oldCard.replaceWith($newCard);
+            bindCard($newCard);
+            updateCounts();
+        }
+
+        function handleStageChange($card, targetStage, originalStage) {
+            if (targetStage === originalStage) {
+                updateCounts();
+                return;
+            }
+            $.ajax({
+                url: ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    ajax: true,
+                    action: 'updateInquiryStage',
+                    id_inquiry: $card.data('inquiry-id'),
+                    stage: targetStage,
+                    status: stageStatuses[targetStage] || ''
+                }
+            }).done(function (response) {
+                if (response && response.success && response.card_html) {
+                    replaceCard($card, response.card_html);
+                } else {
+                    revertCard($card, originalStage);
+                    notifyError(response && response.message ? response.message : (config.messages && config.messages.updateError));
+                }
+            }).fail(function () {
+                revertCard($card, originalStage);
+                notifyError(config.messages && config.messages.updateError);
+            });
+        }
+
+        function revertCard($card, stage) {
+            var $list = $board.find('[data-stage-list="' + stage + '"]');
+            $list.append($card);
+            updateCounts();
+        }
+
+        function promptReminder($card) {
+            var id = $card.data('inquiry-id');
+            var existing = $card.find('.inquiry-card-reminder').text();
+            var promptMessage = config.messages && config.messages.reminderPrompt ? config.messages.reminderPrompt : 'Enter reminder datetime (YYYY-MM-DD HH:MM) or leave blank to clear.';
+            var value = window.prompt(promptMessage, existing ? existing.replace(/^.*:/, '').trim() : '');
+            if (value === null) {
+                return;
+            }
+            $.ajax({
+                url: ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    ajax: true,
+                    action: 'scheduleInquiryReminder',
+                    id_inquiry: id,
+                    reminder_at: value
+                }
+            }).done(function (response) {
+                if (response && response.success) {
+                    refreshCard(id, function () {
+                        if (!value) {
+                            notifySuccess(config.messages && config.messages.reminderCleared);
+                        } else {
+                            notifySuccess(config.messages && config.messages.reminderSaved);
+                        }
+                    });
+                } else {
+                    notifyError(response && response.message ? response.message : (config.messages && config.messages.updateError));
+                }
+            }).fail(function () {
+                notifyError(config.messages && config.messages.updateError);
+            });
+        }
+
+        function openNotesModal(id) {
+            $noteForm[0].reset();
+            $noteForm.find('input[name="id_inquiry"]').val(id);
+            $noteHistory.empty();
+            $.ajax({
+                url: ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    ajax: true,
+                    action: 'getInquiryDetails',
+                    id_inquiry: id
+                }
+            }).done(function (response) {
+                if (response && response.success) {
+                    renderNoteHistory(response.notes || []);
+                    $noteModal.modal('show');
+                } else {
+                    notifyError(response && response.message ? response.message : (config.messages && config.messages.updateError));
+                }
+            }).fail(function () {
+                notifyError(config.messages && config.messages.updateError);
+            });
+        }
+
+        function renderNoteHistory(notes) {
+            $noteHistory.empty();
+            if (!notes || !notes.length) {
+                $noteHistory.append('<p class="text-muted">' + (config.messages && config.messages.noNotes || 'No notes yet.') + '</p>');
+                return;
+            }
+            $.each(notes, function (_, note) {
+                var mailBadge = parseInt(note.is_mail, 10) ? '<span class="label label-info">Mail</span> ' : '';
+                var employee = note.id_employee ? (' #' + note.id_employee) : '';
+                var meta = $('<div class="note-meta"/>').html(mailBadge + (note.date_add || '') + employee);
+                var body = $('<div class="note-body"/>').text(note.note || '');
+                var container = $('<div class="note-item"/>').append(meta).append(body);
+                $noteHistory.append(container);
+            });
+        }
+
+        function refreshCard(id, callback) {
+            $.ajax({
+                url: ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    ajax: true,
+                    action: 'getInquiryDetails',
+                    id_inquiry: id
+                }
+            }).done(function (response) {
+                if (response && response.success && response.card_html) {
+                    var $card = $board.find('.inquiry-card[data-inquiry-id="' + id + '"]');
+                    if ($card.length) {
+                        replaceCard($card, response.card_html);
+                    }
+                    if (callback) {
+                        callback(response);
+                    }
+                }
+            });
+        }
+
+        $board.find('.inquiry-column-body').sortable({
+            connectWith: '.inquiry-column-body',
+            placeholder: 'inquiry-card-placeholder',
+            forcePlaceholderSize: true,
+            start: function (event, ui) {
+                ui.item.addClass('dragging');
+                ui.item.data('original-stage', ui.item.closest('.inquiry-column').data('stage'));
+            },
+            stop: function (event, ui) {
+                ui.item.removeClass('dragging');
+                var $card = ui.item;
+                var targetStage = $card.closest('.inquiry-column').data('stage');
+                var originalStage = $card.data('original-stage');
+                handleStageChange($card, targetStage, originalStage);
+                $card.removeData('original-stage');
+                updateCounts();
+            },
+            over: function (event, ui) {
+                $(this).addClass('highlight-drop');
+            },
+            out: function (event, ui) {
+                $(this).removeClass('highlight-drop');
+            },
+            receive: function (event, ui) {
+                $(this).addClass('highlight-drop');
+            },
+            deactivate: function () {
+                $board.find('.highlight-drop').removeClass('highlight-drop');
+            }
+        }).disableSelection();
+
+        $board.find('.inquiry-card').each(function () {
+            bindCard($(this));
+        });
+
+        $('#inquiry-create-trigger').on('click', function (event) {
+            event.preventDefault();
+            $createModal.find('form')[0].reset();
+            $createModal.modal('show');
+        });
+
+        $('#inquiry-refresh-board').on('click', function (event) {
+            event.preventDefault();
+            window.location.reload();
+        });
+
+        $('#inquiry-create-form').on('submit', function (event) {
+            event.preventDefault();
+            var formData = $(this).serializeArray();
+            formData.push({ name: 'ajax', value: true });
+            formData.push({ name: 'action', value: 'createInquiry' });
+            $.ajax({
+                url: ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: $.param(formData)
+            }).done(function (response) {
+                if (response && response.success && response.card_html) {
+                    var stage = response.inquiry && response.inquiry.stage ? response.inquiry.stage : 'inbox';
+                    var $list = $board.find('[data-stage-list="' + stage + '"]');
+                    var $card = $(response.card_html);
+                    $list.prepend($card);
+                    bindCard($card);
+                    updateCounts();
+                    notifySuccess(config.messages && config.messages.createSuccess);
+                    $createModal.modal('hide');
+                } else {
+                    notifyError(response && response.message ? response.message : (config.messages && config.messages.updateError));
+                }
+            }).fail(function () {
+                notifyError(config.messages && config.messages.updateError);
+            });
+        });
+
+        $noteForm.on('submit', function (event) {
+            event.preventDefault();
+            var formData = $(this).serializeArray();
+            formData.push({ name: 'ajax', value: true });
+            formData.push({ name: 'action', value: 'addInquiryNote' });
+            $.ajax({
+                url: ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: $.param(formData)
+            }).done(function (response) {
+                if (response && response.success) {
+                    var id = $noteForm.find('input[name="id_inquiry"]').val();
+                    if (response.notes) {
+                        renderNoteHistory(response.notes);
+                    }
+                    refreshCard(id);
+                    notifySuccess(config.messages && config.messages.noteSaved);
+                    $noteForm[0].reset();
+                } else {
+                    notifyError(response && response.message ? response.message : (config.messages && config.messages.updateError));
+                }
+            }).fail(function () {
+                notifyError(config.messages && config.messages.updateError);
+            });
+        });
+    });
+})(jQuery);

--- a/modules/hotelreservationsystem/views/templates/admin/inquiries/_partials/card.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/inquiries/_partials/card.tpl
@@ -1,0 +1,60 @@
+<div class="inquiry-card" data-inquiry-id="{$inquiry.id_inquiry|intval}" data-stage="{$inquiry.stage|escape:'htmlall':'UTF-8'}">
+    <div class="inquiry-card-header">
+        <span class="label label-default">{$inquiry.reference|escape:'htmlall':'UTF-8'}</span>
+        <span class="inquiry-card-status">{if isset($status_definitions[$inquiry.status])}{$status_definitions[$inquiry.status]|escape:'htmlall':'UTF-8'}{else}{$inquiry.status|escape:'htmlall':'UTF-8'}{/if}</span>
+    </div>
+    <div class="inquiry-card-body">
+        <strong class="inquiry-card-subject">{$inquiry.subject|escape:'htmlall':'UTF-8'}</strong>
+        {if $inquiry.requester_name || $inquiry.requester_email}
+            <div class="inquiry-card-contact">
+                <i class="icon-user"></i>
+                {if $inquiry.requester_name}<span>{$inquiry.requester_name|escape:'htmlall':'UTF-8'}</span>{/if}
+                {if $inquiry.requester_email}
+                    <span>&lt;{$inquiry.requester_email|escape:'htmlall':'UTF-8'}&gt;</span>
+                {/if}
+            </div>
+        {/if}
+        {if $inquiry.check_in || $inquiry.check_out}
+            <div class="inquiry-card-dates">
+                <i class="icon-calendar"></i>
+                <span>
+                    {if $inquiry.check_in}{$inquiry.check_in|escape:'htmlall':'UTF-8'}{else}?{/if}
+                    –
+                    {if $inquiry.check_out}{$inquiry.check_out|escape:'htmlall':'UTF-8'}{else}?{/if}
+                </span>
+            </div>
+        {/if}
+        {if $inquiry.resource_request}
+            <div class="inquiry-card-resources">{$inquiry.resource_request|escape:'htmlall':'UTF-8'}</div>
+        {/if}
+        {if $inquiry.reminder_at}
+            <div class="inquiry-card-reminder text-warning">
+                <i class="icon-bell"></i> {l s='Reminder' mod='hotelreservationsystem'}: {$inquiry.reminder_at|escape:'htmlall':'UTF-8'}
+            </div>
+        {/if}
+        {if $inquiry.last_note_at}
+            <div class="inquiry-card-noteinfo">
+                <i class="icon-sticky-note"></i> {l s='Last note' mod='hotelreservationsystem'}: {$inquiry.last_note_at|escape:'htmlall':'UTF-8'}
+            </div>
+        {/if}
+    </div>
+    <div class="inquiry-card-footer">
+        <div class="inquiry-card-assignee">
+            <label>{l s='Assigned' mod='hotelreservationsystem'}</label>
+            <select class="form-control input-sm inquiry-assignee" data-role="assignee">
+                <option value="">{l s='Unassigned' mod='hotelreservationsystem'}</option>
+                {foreach from=$board_employees item=employee}
+                    <option value="{$employee.id_employee|intval}"{if isset($inquiry.assigned_to) && $inquiry.assigned_to == $employee.id_employee} selected{/if}>{$employee.name|escape:'htmlall':'UTF-8'}</option>
+                {/foreach}
+            </select>
+        </div>
+        <div class="inquiry-card-actions">
+            <button type="button" class="btn btn-link btn-xs inquiry-set-reminder" data-role="reminder">
+                <i class="icon-bell"></i>
+            </button>
+            <button type="button" class="btn btn-link btn-xs inquiry-open-notes" data-role="notes">
+                <i class="icon-comments"></i>
+            </button>
+        </div>
+    </div>
+</div>

--- a/modules/hotelreservationsystem/views/templates/admin/inquiries/_partials/index.php
+++ b/modules/hotelreservationsystem/views/templates/admin/inquiries/_partials/index.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License version 3.0
+ * that is bundled with this package in the file LICENSE.md
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/license/osl-3-0-php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to support@qloapps.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to a newer
+ * versions in the future. If you wish to customize this module for your needs
+ * please refer to https://store.webkul.com/customisation-guidelines for more information.
+ *
+ * @author Webkul IN
+ * @copyright Since 2010 Webkul
+ * @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../');
+exit;

--- a/modules/hotelreservationsystem/views/templates/admin/inquiries/index.php
+++ b/modules/hotelreservationsystem/views/templates/admin/inquiries/index.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License version 3.0
+ * that is bundled with this package in the file LICENSE.md
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/license/osl-3-0-php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to support@qloapps.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to a newer
+ * versions in the future. If you wish to customize this module for your needs
+ * please refer to https://store.webkul.com/customisation-guidelines for more information.
+ *
+ * @author Webkul IN
+ * @copyright Since 2010 Webkul
+ * @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../');
+exit;

--- a/modules/hotelreservationsystem/views/templates/admin/inquiries/kanban.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/inquiries/kanban.tpl
@@ -1,0 +1,129 @@
+{extends file="helpers/view/view.tpl"}
+
+{block name="override_tpl"}
+<div class="panel inquiry-board-panel">
+    <div class="panel-heading">
+        <i class="icon-comments"></i> {l s='Inquiry board' mod='hotelreservationsystem'}
+        <div class="pull-right">
+            <button type="button" class="btn btn-default" id="inquiry-refresh-board">
+                <i class="icon-refresh"></i> {l s='Refresh' mod='hotelreservationsystem'}
+            </button>
+            <button type="button" class="btn btn-primary" id="inquiry-create-trigger">
+                <i class="icon-plus"></i> {l s='New inquiry' mod='hotelreservationsystem'}
+            </button>
+        </div>
+    </div>
+    <div class="panel-body">
+        <div class="row" id="hotel-inquiry-board">
+            {foreach from=$stage_definitions key=stageKey item=stageDefinition}
+                <div class="col-md-3 col-sm-6 inquiry-column" data-stage="{$stageKey|escape:'htmlall':'UTF-8'}">
+                    <div class="inquiry-column-header">
+                        <span class="inquiry-column-title">{$stageDefinition.label|escape:'htmlall':'UTF-8'}</span>
+                        <span class="badge" data-stage-count="{$stageKey|escape:'htmlall':'UTF-8'}">{if isset($inquiry_dataset[$stageKey])}{count($inquiry_dataset[$stageKey])}{else}0{/if}</span>
+                    </div>
+                    <div class="inquiry-column-body" data-stage-list="{$stageKey|escape:'htmlall':'UTF-8'}">
+                        {if isset($inquiry_dataset[$stageKey]) && $inquiry_dataset[$stageKey]}
+                            {foreach from=$inquiry_dataset[$stageKey] item=inquiry}
+                                {include file="modules/hotelreservationsystem/views/templates/admin/inquiries/_partials/card.tpl" inquiry=$inquiry stage_definitions=$stage_definitions status_definitions=$status_definitions board_employees=$board_employees}
+                            {/foreach}
+                        {/if}
+                    </div>
+                </div>
+            {/foreach}
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="inquiry-create-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form id="inquiry-create-form">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' mod='hotelreservationsystem'}"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title"><i class="icon-plus"></i> {l s='Create inquiry' mod='hotelreservationsystem'}</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="inquiry-subject" class="control-label">{l s='Subject' mod='hotelreservationsystem'}</label>
+                        <input type="text" class="form-control" id="inquiry-subject" name="subject" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="inquiry-requester-name" class="control-label">{l s='Requester name' mod='hotelreservationsystem'}</label>
+                        <input type="text" class="form-control" id="inquiry-requester-name" name="requester_name">
+                    </div>
+                    <div class="form-group">
+                        <label for="inquiry-requester-email" class="control-label">{l s='Requester email' mod='hotelreservationsystem'}</label>
+                        <input type="email" class="form-control" id="inquiry-requester-email" name="requester_email">
+                    </div>
+                    <div class="form-group">
+                        <label for="inquiry-requester-phone" class="control-label">{l s='Requester phone' mod='hotelreservationsystem'}</label>
+                        <input type="text" class="form-control" id="inquiry-requester-phone" name="requester_phone">
+                    </div>
+                    <div class="form-group">
+                        <label class="control-label">{l s='Requested stay' mod='hotelreservationsystem'}</label>
+                        <div class="row">
+                            <div class="col-sm-6">
+                                <input type="date" class="form-control" name="check_in" placeholder="{l s='Check-in' mod='hotelreservationsystem'}">
+                            </div>
+                            <div class="col-sm-6">
+                                <input type="date" class="form-control" name="check_out" placeholder="{l s='Check-out' mod='hotelreservationsystem'}">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="inquiry-resource-request" class="control-label">{l s='Requested rooms or spaces' mod='hotelreservationsystem'}</label>
+                        <textarea class="form-control" id="inquiry-resource-request" name="resource_request" rows="3"></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="inquiry-internal-notes" class="control-label">{l s='Internal notes' mod='hotelreservationsystem'}</label>
+                        <textarea class="form-control" id="inquiry-internal-notes" name="internal_notes" rows="3"></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="inquiry-assigned" class="control-label">{l s='Assign to' mod='hotelreservationsystem'}</label>
+                        <select class="form-control" id="inquiry-assigned" name="assigned_to">
+                            <option value="">{l s='Unassigned' mod='hotelreservationsystem'}</option>
+                            {foreach from=$board_employees item=employee}
+                                <option value="{$employee.id_employee|intval}">{$employee.name|escape:'htmlall':'UTF-8'}</option>
+                            {/foreach}
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">{l s='Cancel' mod='hotelreservationsystem'}</button>
+                    <button type="submit" class="btn btn-primary">{l s='Save inquiry' mod='hotelreservationsystem'}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="inquiry-note-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form id="inquiry-note-form">
+                <input type="hidden" name="id_inquiry" value="">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' mod='hotelreservationsystem'}"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title"><i class="icon-envelope"></i> {l s='Add note' mod='hotelreservationsystem'}</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="inquiry-note-body" class="control-label">{l s='Note' mod='hotelreservationsystem'}</label>
+                        <textarea class="form-control" id="inquiry-note-body" name="note" rows="4" required></textarea>
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" name="is_mail" value="1"> {l s='Send as mail note to requester' mod='hotelreservationsystem'}
+                        </label>
+                    </div>
+                    <div class="inquiry-note-history"></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">{l s='Cancel' mod='hotelreservationsystem'}</button>
+                    <button type="submit" class="btn btn-primary">{l s='Save note' mod='hotelreservationsystem'}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{/block}

--- a/roadmap.md
+++ b/roadmap.md
@@ -9,9 +9,9 @@ This roadmap tracks how the Kunstort Lehnin fork evolves from a de-bloated QloAp
 - ✅ **Webservice disabled** – `/webservice` responds with HTTP 410 and admin tooling for API keys has been excised to reduce attack surface.
 
 ## Phase 1 – Inquiry Workflow Maturity (🚧 In progress)
-- 🚧 **Timeline interaction upgrades** – add drag-and-drop reallocation with conflict detection against room disables and capacity rules.
-- ⏳ **Inquiry entity & board** – replace cart-derived booking scaffolding with a dedicated Inquiry model, Kanban board UI and assignment workflow, including reminders and mail notes.
-- ⏳ **API endpoints** – expose REST endpoints for timeline updates, inquiry status changes and availability lookups to support the new UI components.
+- ✅ **Timeline interaction upgrades** – add drag-and-drop reallocation with conflict detection against room disables and capacity rules.
+- 🚧 **Inquiry entity & board** – replace cart-derived booking scaffolding with a dedicated Inquiry model, Kanban board UI and assignment workflow, including reminders and mail notes.
+- ✅ **API endpoints** – expose REST endpoints for timeline updates, inquiry status changes and availability lookups to support the new UI components.
 
 ## Phase 2 – Resource & Pricing Model (⏳ Planned)
 - ⏳ **Resource taxonomy** – add `resource_kind`, capacity descriptors and amenities metadata to rooms, ateliers, seminar spaces and gastronomy units.


### PR DESCRIPTION
## Summary
- add a drag-and-drop workflow to the admin booking timeline with conflict validation
- introduce a dedicated inquiry model, Kanban board UI and reminder/note handling
- expose JSON endpoints for timeline moves, inquiry updates and availability lookups and document the changes

## Testing
- php -l modules/hotelreservationsystem/classes/HotelInquiry.php
- php -l modules/hotelreservationsystem/classes/HotelInquiryNote.php
- php -l modules/hotelreservationsystem/controllers/admin/AdminHotelInquiriesController.php
- php -l modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
- php -l modules/hotelreservationsystem/hotelreservationsystem.php
- php -l modules/hotelreservationsystem/upgrade/upgrade-1.8.0.php

------
https://chatgpt.com/codex/tasks/task_e_68d31876b6cc8321b0dbff67faacb798