### PR TITLE
Document resource taxonomy and automation blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ All Kunstort-specific flags live in `config/defines_custom.inc.php`:
 Use these constants in future contributions to gate legacy commerce flows.
 
 ## Development Priorities
-- Broaden resource annotations (rooms, ateliers, gastronomy) to enrich availability storytelling and reporting.
-- Replace the front-office room list with storytelling-driven templates and an enquiry form.
-- Provide CSV/ICS exports to support residency and seminar scheduling outside the app.
+- Broaden resource annotations (rooms, ateliers, gastronomy) to enrich availability storytelling and reporting. See [`docs/blueprints/resource-taxonomy.md`](docs/blueprints/resource-taxonomy.md) for the canonical data model.
+- Replace the front-office room list with storytelling-driven templates and an enquiry form tied to curated packages. Content strategy is outlined in the taxonomy blueprint and will drive copy blocks surfaced on offer pages.
+- Introduce configurable rate plans and bundled packages so inquiries can be priced consistently, following [`docs/blueprints/rate-plans-packages.md`](docs/blueprints/rate-plans-packages.md).
+- Provide CSV/ICS exports plus internal notifications to support residency and seminar scheduling outside the app, grounded in [`docs/blueprints/operations-automation.md`](docs/blueprints/operations-automation.md).
 
 See [`checklist.md`](checklist.md) for the current implementation status.
 

--- a/checklist.md
+++ b/checklist.md
@@ -14,6 +14,8 @@
 
 ## In Progress
 - [ ] Draft resource taxonomy for rooms, ateliers, gastronomy areas.
+- [ ] Design configurable rate plan entities and package bundling rules.
+- [ ] Outline automation scope for housekeeping, notifications and exports.
 
 ## Planned
 - [ ] Build out the dedicated inquiry submission pipeline on top of the new entry point.

--- a/concept.md
+++ b/concept.md
@@ -32,8 +32,12 @@ The detailed multi-phase plan lives in [`roadmap.md`](roadmap.md). Immediate pri
 
 1. **Timeline interaction upgrades** *(complete)* – drag-and-drop reallocation on the admin timeline now blocks conflicts against disabled rooms and occupancy limits, and powers the new REST endpoints.
 2. **Inquiry workflow foundations** *(complete)* – the dedicated Inquiry model, Kanban board, reminders and mail notes replace cart-driven scaffolding in the back office; notes can optionally email guests for a documented audit trail.
-3. **Resource taxonomy groundwork** – model `resource_kind`, capacity descriptors and amenities on rooms, ateliers and gastronomy spaces to unlock richer storytelling and reporting.
-4. **Frontend storytelling** – refactor offer pages to present curated narratives, availability cues and inquiry entry points instead of commodity pricing widgets.
+3. **Resource taxonomy groundwork** – model `resource_kind`, capacity descriptors and amenities on rooms, ateliers and gastronomy spaces to unlock richer storytelling and reporting. Detailed deliverables and data models now live in [`docs/blueprints/resource-taxonomy.md`](docs/blueprints/resource-taxonomy.md).
+4. **Frontend storytelling** – refactor offer pages to present curated narratives, availability cues and inquiry entry points instead of commodity pricing widgets. Copy strategy, media pairing and availability cues will be coordinated with the taxonomy work so the front office can reuse the same metadata without bespoke duplication.
+5. **Rate plans & packages** – layer configurable plans (BAR, corporate, residency programmes) and bundled offers for ateliers/catering as described in [`docs/blueprints/rate-plans-packages.md`](docs/blueprints/rate-plans-packages.md) to keep quoting grounded in a consistent rule set.
+6. **Operations automation** – bootstrap housekeeping, maintenance, notification and export scaffolding according to [`docs/blueprints/operations-automation.md`](docs/blueprints/operations-automation.md) so staff tooling evolves alongside the taxonomy changes.
+
+These additions extend the original near-term plan without changing the underlying principle: resource clarity first, then progressive automation that remains transparent to staff.
 
 ## Longer-Term Ideas
 - Replace leftover commerce terminology in the database schema and UI strings.

--- a/docs/blueprints/operations-automation.md
+++ b/docs/blueprints/operations-automation.md
@@ -1,0 +1,54 @@
+# Operations Automation Blueprint
+
+This blueprint describes the automation layer for housekeeping, maintenance, staff notifications and data exports.
+
+## Housekeeping & Maintenance Tasks
+- Generate arrival/departure task lists per day based on confirmed bookings and residency timelines.
+- Classify tasks by resource kind (room turnarounds, atelier resets, gastronomy prep) and assign to staff teams.
+- Track statuses (`pending`, `in_progress`, `clean`, `needs_repair`) with timestamped employee updates.
+- Capture maintenance notes, photos and follow-up reminders for tasks flagged as `needs_repair`.
+- Provide printable and mobile-friendly checklists with offline caching.
+
+### Data Model Additions
+| Table | Purpose |
+| --- | --- |
+| `ps_kl_task` | Master task table storing resource reference, type (`housekeeping`, `maintenance`), status, due window. |
+| `ps_kl_task_assignment` | Pivot linking tasks to employees or teams with priority and acknowledgement metadata. |
+| `ps_kl_task_note` | Logbook for status transitions, notes and attachments. |
+
+Tasks are generated via a cron job and can also be created manually from the resource timeline or inquiry board.
+
+## Internal Notifications
+- Subscribe employees or teams to events (new inquiry, timeline move, overdue task, quote approval).
+- Deliver notifications via in-app inbox, daily digest email and optional ICS feed subscription.
+- Provide quiet hours and channel preferences per employee.
+
+### Data Model
+| Table | Purpose |
+| --- | --- |
+| `ps_kl_notification_subscription` | Employee preferences for event types and delivery channels. |
+| `ps_kl_notification_event` | Canonical record of events emitted by the system (subject, payload, reference IDs). |
+| `ps_kl_notification_delivery` | Tracks channel-specific deliveries (email, digest, calendar) and acknowledgement status. |
+
+## ICS/CSV Exports
+- Provide filtered exports for residency calendars, atelier schedules and event planning.
+- Support weekly digest ICS feed for Google/Outlook and ad-hoc CSV downloads with timezone-corrected timestamps.
+- Ensure exports respect permissions (e.g. residency team vs gastronomy team data scopes).
+
+### Implementation Notes
+- Build export services that accept filters (resource kinds, programme tags, status) and return standardised DTOs.
+- Use ICS generation library (e.g. `eluceo/ical`) and native PHP CSV functions.
+- Cache export payloads for quick regeneration but invalidate on booking/inquiry changes.
+
+## Integrations & UI
+- Add a **Operations → Tasks** admin screen with Kanban/list toggle, filters by resource and status, and bulk actions.
+- Embed housekeeping summary widgets in the timeline view (today/tomorrow tasks, overdue items).
+- Allow inquiry board to trigger maintenance tasks directly when issues are reported by guests.
+
+## Deliverables
+1. Database tables and corresponding `ObjectModel` classes for tasks, notes, notifications and deliveries.
+2. Cron command that generates daily housekeeping/maintenance tasks from arrival/departure data.
+3. Admin UI for managing tasks, including quick status updates and printable checklists.
+4. Notification dispatcher services (in-app, email, ICS feed generation) with preference management.
+5. Export controllers for ICS/CSV plus automated tests covering generation and permissions.
+

--- a/docs/blueprints/rate-plans-packages.md
+++ b/docs/blueprints/rate-plans-packages.md
@@ -1,0 +1,52 @@
+# Rate Plans & Packages Blueprint
+
+This blueprint outlines how flexible price plans and packages will integrate with the Kunstort Lehnin fork.
+
+## Goals
+- Support configurable rate plans (BAR, corporate, residency programmes, cultural partners) with seasonal overrides.
+- Allow packages that bundle accommodation, atelier usage, catering and experiences into weekly or event-based offers.
+- Keep pricing decisions traceable by logging applied rules, adjustments and approvals.
+- Expose plans/packages to the inquiry workflow so staff can quote consistent pricing quickly.
+
+## Core Entities
+| Entity | Description |
+| --- | --- |
+| `KLRatePlan` | Defines plan code, display name, eligibility rules (resource kinds, segments), pricing method and cancellation policy. |
+| `KLRatePlanSeason` | Date-bounded adjustments (percentage or fixed modifiers) plus minimum stay, occupancy or lead-time rules. |
+| `KLPackage` | Bundled offer that references one or more rate plans, resources, services and optional experience slots. |
+| `KLPackageComponent` | Itemised line describing what is included (lodging night, atelier session, meal service, equipment). |
+| `KLQuote` | Stores generated quotes linked to inquiries, capturing selected plan/package, price breakdown and approval status. |
+
+## Pricing Engine Sketch
+1. Staff selects a resource and dates inside the inquiry board or booking timeline.
+2. The system fetches applicable rate plans (`resource_kind`, corporate tag, residency programme, etc.).
+3. Staff chooses a rate plan or package. The pricing engine:
+   - Applies base price (nightly or weekly) from the plan.
+   - Applies seasonal overrides and adjustments.
+   - Adds package components (atelier usage, catering) and calculates net totals.
+   - Generates tax breakdown according to existing QloApps configuration.
+4. A `KLQuote` record is stored with the computed lines. Quotes can be revised with audit trail of manual edits.
+
+## Admin Interfaces
+- **Rate Plans**: CRUD grid with plan metadata, eligibility conditions (resource kinds, residency tags), and seasonal modifiers.
+- **Packages**: Builder UI where staff assemble components (resource nights, catering, experiences) via drag-and-drop.
+- **Quote Review**: Inquiry detail sidebar that lists generated quotes, allows approval, copy-to-email and export to PDF.
+
+## Front-Office Storytelling
+- Offer pages showcase curated packages with imagery, highlight copy and availability cues drawn from the taxonomy tables.
+- CTA buttons trigger the inquiry modal pre-filled with the selected package and preferred dates.
+
+## Technical Considerations
+- Store monetary values in the default currency minor units to avoid floating point drift.
+- Reuse PrestaShop `CartRule` style condition builders where possible, but keep evaluation server-side inside dedicated classes.
+- Ensure packages gracefully degrade when included amenities are unavailable for selected dates (surface warnings, allow manual overrides).
+- Localise plan/package descriptions using the existing translation infrastructure.
+
+## Deliverables
+1. Database tables `_DB_PREFIX_kl_rate_plan`, `_DB_PREFIX_kl_rate_plan_lang`, `_DB_PREFIX_kl_rate_plan_season`, `_DB_PREFIX_kl_package`, `_DB_PREFIX_kl_package_lang`, `_DB_PREFIX_kl_package_component`, `_DB_PREFIX_kl_quote`.
+2. ObjectModel classes for each entity and services for rule evaluation.
+3. Admin controllers and Vue components for plan/package management.
+4. Inquiry board integration for quote generation and tracking.
+5. Exportable PDF quote template using TCPDF/FPDF.
+6. Automated tests covering rate selection, seasonal pricing, package totals and quote persistence.
+

--- a/docs/blueprints/resource-taxonomy.md
+++ b/docs/blueprints/resource-taxonomy.md
@@ -1,0 +1,50 @@
+# Resource Taxonomy Blueprint
+
+This document captures the upcoming taxonomy work for Kunstort Lehnin. It extends the current room and product models so every
+campus asset can be described consistently across the back office, front office storytelling, rate plans and exports.
+
+## Objectives
+- Model a `resource_kind` that disambiguates rooms, ateliers, seminar spaces, gastronomy units and shared infrastructure.
+- Record structured capacity descriptors for people, equipment and spatial constraints.
+- Maintain a curated amenities catalogue to power storytelling, task automation and rate/package eligibility.
+- Provide translation-ready copy blocks (short name, highlight sentence, long description) for front-office use.
+- Keep metadata versioned and auditable so staff can iterate on descriptions without losing history.
+
+## Data Model Sketch
+
+| Table | Purpose |
+| --- | --- |
+| `ps_kl_resource_profile` | One row per resource (room, atelier, gastronomy unit) with basic taxonomy fields. |
+| `ps_kl_resource_capacity` | Structured capacity descriptors keyed by resource (people/adult/child counts, area, equipment limits). |
+| `ps_kl_resource_amenity` | Amenity catalogue with category, icon, and localisation keys. |
+| `ps_kl_resource_amenity_link` | Many-to-many table linking resources to amenities plus optional notes (e.g. “upon request”). |
+| `ps_kl_resource_story` | Localised storytelling blocks for the front office (headline, excerpt, detailed body, image references). |
+| `ps_kl_resource_history` | Append-only change log referencing employees and timestamps for metadata edits. |
+
+All tables are prefixed with `_DB_PREFIX_kl_` to stay namespaced. Profiles reference `id_hotel_room` for rooms, and dedicated
+IDs for non-room spaces (ateliers, gastronomy) to keep future expansion possible.
+
+## Admin UX Notes
+- Extend the **Hotel Reservation System → Rooms** edit form with a new “Profile” tab that surfaces the taxonomy fields.
+- Mirror the profile UI in Atelier and Gastronomy controllers (or create a shared Vue component fed by AJAX endpoints).
+- Provide amenity management in **Catalog → Amenities** with drag-and-drop categorisation and icon upload.
+- Add a change log sidebar showing recent edits with rollback links (soft rollback that clones a previous version).
+
+## API Exposure
+- Extend the internal JSON endpoints to include taxonomy metadata alongside availability payloads.
+- Add `/api/resource-profile/{id}` endpoints guarded by employee tokens so the front office and housekeeping dashboard can
+fetch consistent data.
+
+## Dependencies & Risks
+- Requires data migration for existing rooms; create a CLI helper to seed defaults based on current room type labels.
+- Amenity taxonomy should avoid duplication with existing feature lists in `ps_hotel_room_features`; we will migrate
+and deprecate the old list gradually.
+- Storytelling blocks rely on media assets; ensure the media library supports multiple renditions and alt text.
+
+## Deliverables
+1. Database migration scripts (install + upgrade) for the new tables.
+2. PHP `ObjectModel` classes: `KLResourceProfile`, `KLResourceCapacity`, `KLAmenity`, `KLAmenityLink`, `KLResourceStory`.
+3. Admin controllers/forms for managing metadata, including translation fields.
+4. REST endpoints exposing taxonomy data for the front office and exports.
+5. Unit tests for the new models and data accessors (seeded with fixtures for room/atelier/gastronomy resources).
+

--- a/roadmap.md
+++ b/roadmap.md
@@ -14,13 +14,13 @@ This roadmap tracks how the Kunstort Lehnin fork evolves from a de-bloated QloAp
 - ✅ **API endpoints** – expose REST endpoints for timeline updates, inquiry status changes and availability lookups to support the new UI components.
 
 ## Phase 2 – Resource & Pricing Model (⏳ Planned)
-- ⏳ **Resource taxonomy** – add `resource_kind`, capacity descriptors and amenities metadata to rooms, ateliers, seminar spaces and gastronomy units.
-- ⏳ **Rate plans & packages** – introduce configurable price plans (BAR, corporate, residency programmes) plus bundled packages for weekly ateliers, catering-inclusive stays, etc.
-- ⏳ **Frontend storytelling** – rebuild offer pages to surface the new taxonomy with curated copy, imagery and availability cues.
+- ⏳ **Resource taxonomy** – add `resource_kind`, capacity descriptors and amenities metadata to rooms, ateliers, seminar spaces and gastronomy units. Refer to [`docs/blueprints/resource-taxonomy.md`](docs/blueprints/resource-taxonomy.md) for the canonical schema, admin UX and API exposure plan.
+- ⏳ **Rate plans & packages** – introduce configurable price plans (BAR, corporate, residency programmes) plus bundled packages for weekly ateliers, catering-inclusive stays, etc., as laid out in [`docs/blueprints/rate-plans-packages.md`](docs/blueprints/rate-plans-packages.md).
+- ⏳ **Frontend storytelling** – rebuild offer pages to surface the new taxonomy with curated copy, imagery and availability cues informed by the taxonomy and packages.
 
 ## Phase 3 – Operations Automation (⏳ Planned)
-- ⏳ **Housekeeping & maintenance tasks** – auto-generate cleaning and technical checklists from arrival/departure data and allow staff to report statuses (clean, in progress, needs repair).
-- ⏳ **Internal notifications** – hook inquiry and timeline events into task reminders, digest emails and calendar feeds for staff.
+- ⏳ **Housekeeping & maintenance tasks** – auto-generate cleaning and technical checklists from arrival/departure data and allow staff to report statuses (clean, in progress, needs repair). Architectural notes live in [`docs/blueprints/operations-automation.md`](docs/blueprints/operations-automation.md).
+- ⏳ **Internal notifications** – hook inquiry and timeline events into task reminders, digest emails and calendar feeds for staff following the same blueprint.
 - ⏳ **ICS/CSV exports** – deliver calendar and reporting exports for residency, seminar and event planning.
 
 ## Phase 4 – Reporting & Integrations (⏳ Planned)


### PR DESCRIPTION
## Summary
- Add blueprint documents for resource taxonomy, rate plans & packages, and operations automation.
- Update concept, checklist, roadmap and README to reference the new blueprints and expanded scope.

## Testing
- Not run (documentation-only changes).


------
https://chatgpt.com/codex/tasks/task_e_68d327342e0c832184681b16bb4f3731