### PR TITLE
Replace residency mockups with resource-driven showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Key characteristics of the fork:
 - 📨 **Inquiry workflow** – the legacy checkout paths now forward to an inquiry landing page so staff can confirm curated requests manually.
 - 🔌 **Offline-friendly admin** – the Addons and Theme catalogues show local installation guidance instead of remote marketplace iframes.
 - 🧭 **Residency navigation** – the front-office header ships with a static residency nav bar and in-house quick links; cart/account/newsletter/social blocks have been excised from both the theme overrides and the module set.
+- 🗺️ **Resource showcase** – the home page now renders a residency showcase fed by published resource profiles so rooms, studios, gastronomy and programme spaces surface real capacity and availability cues.
 - 🔒 **Legacy API removed** – `/webservice` now responds with HTTP 410 and the back office no longer advertises API key management.
 - 💳 **Payments deferred** – legacy bank wire, cheque and PayPal Commerce modules are stripped out so stays are confirmed and settled off-platform.
 - 🔄 **Interactive timeline** – bookings can be reallocated by dragging directly on the admin timeline, with conflict checks against disabled rooms and occupancy caps.
@@ -68,7 +69,8 @@ Dragging a card to another column automatically updates its stage (and default s
 
 ## Resident-Focused Front Office
 
-- The theme header no longer invokes `HOOK_TOP`, `displayTopColumn`, or left/right column placeholders. Instead it renders a static residency navigation bar with anchors for long stays, amenities, dining, experiences, and contact along with direct resident-service shortcuts and support contacts.
+- The theme header no longer invokes `HOOK_TOP`, `displayTopColumn`, or left/right column placeholders. Instead it renders a static residency navigation bar with anchors for residences, studios & ateliers, dining, programme spaces, and contact along with direct resident-service shortcuts and support contacts.
+- The home page now includes a residency showcase block sourced from the new resource taxonomy tables so rooms, ateliers, gastronomy and programme spaces present real metadata (capacity, availability posture, timezone) instead of mock content.
 - The hotel description ribbon is rendered inline from configuration values so the chain name and tagline stay visible without needing module hooks.
 - Legacy e-commerce widgets (`blockcart`, `blockuserinfo`, `blockmyaccount`, `blocknewsletter`, `blocksocial`) have been removed from both `themes/hotel-reservation-theme/modules/` and `modules/`, and their default hook assignments have been stripped from installation metadata so fresh installs or upgrades never attempt to load them.
 - Core controllers now guard newsletter integration points so missing modules do not trigger autoload errors on identity or authentication flows.

--- a/checklist.md
+++ b/checklist.md
@@ -31,3 +31,4 @@
 - [x] Layered drag-and-drop reallocation controls onto the booking timeline with conflict detection.
 - [x] Exposed REST endpoints for timeline edits, inquiry updates and availability lookups.
 - [x] Enabled mail note delivery from the inquiry board so assignees can email guests while logging internal notes.
+- [x] Replaced the front-office residency showcase mockups with live resource profile data and capacity summaries.

--- a/concept.md
+++ b/concept.md
@@ -22,6 +22,7 @@ Create a lean, fully self-hosted hospitality operations tool tailored to Kunstor
 - Resource taxonomy scaffolding now lives in core tables (`kl_resource_profile`, `kl_resource_capacity`, `kl_resource_amenity`, `kl_resource_story`, `kl_resource_history`) with matching `ObjectModel` classes to power upcoming admin forms and APIs.
 - The back office exposes a dedicated **Resource Profiles** tab so staff can edit taxonomy metadata and capacity descriptors for rooms, ateliers and gastronomy spaces while amenity catalogues are prepared.
 - The front-office header ships as a static residency navigation strip with in-house quick links; cart/account/newsletter/social blocks have been removed from both the theme and core module set so no commerce widgets are expected.
+- The front-office home page now surfaces a residency showcase fed by published resource profiles so rooms, ateliers, gastronomy and programme spaces display live metadata instead of mockups.
 - Legacy PrestaShop webservice entry points are stubbed; `/webservice` responds with HTTP 410 and no admin UI exposes API keys.
 
 ## Inquiry Workflow Additions

--- a/modules/hotelreservationsystem/classes/KLResourceProfile.php
+++ b/modules/hotelreservationsystem/classes/KLResourceProfile.php
@@ -117,4 +117,86 @@ class KLResourceProfile extends ObjectModel
             self::RESOURCE_KIND_GASTRONOMY,
         );
     }
+
+    /**
+     * Returns published resource profiles enriched with capacity metrics and optional storytelling data.
+     *
+     * @param int $idLang
+     * @param int|null $idShop
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function getPublishedProfilesWithDetails($idLang, $idShop = null)
+    {
+        $idLang = (int) $idLang;
+        if ($idShop === null) {
+            $context = Context::getContext();
+            $idShop = $context && $context->shop ? (int) $context->shop->id : 0;
+        }
+        $idShop = (int) $idShop;
+
+        $query = new DbQuery();
+        $query->select('p.`id_kl_resource_profile`');
+        $query->select('p.`resource_code`');
+        $query->select('p.`external_reference`');
+        $query->select('p.`resource_kind`');
+        $query->select('p.`display_order`');
+        $query->select('p.`is_bookable`');
+        $query->select('p.`is_published`');
+        $query->select('p.`timezone`');
+        $query->select('cap.`capacity_adults`, cap.`capacity_children`, cap.`capacity_total`, cap.`capacity_seated`, cap.`capacity_standing`, cap.`floor_area_sqm`, cap.`ceiling_height_m`, cap.`notes` AS capacity_notes');
+        $query->select('pl.`name` AS room_type_name');
+        $query->from('kl_resource_profile', 'p');
+        $query->leftJoin('kl_resource_capacity', 'cap', 'cap.`id_kl_resource_profile` = p.`id_kl_resource_profile`');
+        $query->leftJoin(
+            'htl_room_type',
+            'hrt',
+            'hrt.`id` = p.`id_room_type`'
+        );
+        $query->leftJoin(
+            'product_lang',
+            'pl',
+            'pl.`id_product` = hrt.`id_product`'
+            .' AND pl.`id_lang` = '.(int) $idLang
+            .' AND pl.`id_shop` = '.(int) $idShop
+        );
+        $query->where('p.`is_published` = 1');
+        $query->orderBy('p.`resource_kind` ASC, p.`display_order` ASC, p.`resource_code` ASC');
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+        if (!$rows) {
+            return array();
+        }
+
+        $profiles = array();
+        foreach ($rows as $row) {
+            $idProfile = (int) $row['id_kl_resource_profile'];
+            $story = KLResourceStory::getByProfileAndLang($idProfile, $idLang);
+
+            $profiles[] = array(
+                'id_kl_resource_profile' => $idProfile,
+                'resource_code' => $row['resource_code'],
+                'external_reference' => $row['external_reference'],
+                'resource_kind' => $row['resource_kind'],
+                'display_order' => (int) $row['display_order'],
+                'is_bookable' => (bool) $row['is_bookable'],
+                'is_published' => (bool) $row['is_published'],
+                'timezone' => $row['timezone'],
+                'room_type_name' => $row['room_type_name'],
+                'capacity' => array(
+                    'adults' => $row['capacity_adults'] !== null ? (int) $row['capacity_adults'] : null,
+                    'children' => $row['capacity_children'] !== null ? (int) $row['capacity_children'] : null,
+                    'total' => $row['capacity_total'] !== null ? (int) $row['capacity_total'] : null,
+                    'seated' => $row['capacity_seated'] !== null ? (int) $row['capacity_seated'] : null,
+                    'standing' => $row['capacity_standing'] !== null ? (int) $row['capacity_standing'] : null,
+                    'floor_area_sqm' => $row['floor_area_sqm'] !== null ? (float) $row['floor_area_sqm'] : null,
+                    'ceiling_height_m' => $row['ceiling_height_m'] !== null ? (float) $row['ceiling_height_m'] : null,
+                ),
+                'capacity_notes' => $row['capacity_notes'],
+                'story' => $story ?: null,
+            );
+        }
+
+        return $profiles;
+    }
 }

--- a/modules/hotelreservationsystem/hotelreservationsystem.php
+++ b/modules/hotelreservationsystem/hotelreservationsystem.php
@@ -87,6 +87,173 @@ class HotelReservationSystem extends Module
         return $this->display(__FILE__, 'external-navigation-hook.tpl');
     }
 
+    public function hookDisplayHome($params)
+    {
+        $idLang = (int) $this->context->language->id;
+        $idShop = (int) $this->context->shop->id;
+        $profiles = KLResourceProfile::getPublishedProfilesWithDetails($idLang, $idShop);
+        if (!$profiles) {
+            return '';
+        }
+
+        $translator = $this->context->getTranslator();
+        $sections = array(
+            KLResourceProfile::RESOURCE_KIND_ROOM => array(
+                'anchor' => 'residences-overview',
+                'title' => $translator->trans('Residences', array(), 'Modules.Hotelreservationsystem.Front'),
+                'intro' => $translator->trans('Residency rooms prepared for curated stays and guest artists.', array(), 'Modules.Hotelreservationsystem.Front'),
+                'profiles' => array(),
+            ),
+            KLResourceProfile::RESOURCE_KIND_ATELIER => array(
+                'anchor' => 'resident-ateliers',
+                'title' => $translator->trans('Studios & ateliers', array(), 'Modules.Hotelreservationsystem.Front'),
+                'intro' => $translator->trans('Workspaces and ateliers equipped for long-form projects and collaborations.', array(), 'Modules.Hotelreservationsystem.Front'),
+                'profiles' => array(),
+            ),
+            KLResourceProfile::RESOURCE_KIND_GASTRONOMY => array(
+                'anchor' => 'dining',
+                'title' => $translator->trans('Dining & gastronomy', array(), 'Modules.Hotelreservationsystem.Front'),
+                'intro' => $translator->trans('Shared kitchens and dining rooms that support communal meals and catering.', array(), 'Modules.Hotelreservationsystem.Front'),
+                'profiles' => array(),
+            ),
+            KLResourceProfile::RESOURCE_KIND_SEMINAR => array(
+                'anchor' => 'programme-spaces',
+                'title' => $translator->trans('Programme & seminar spaces', array(), 'Modules.Hotelreservationsystem.Front'),
+                'intro' => $translator->trans('Gathering spaces for workshops, talks and performances across the campus.', array(), 'Modules.Hotelreservationsystem.Front'),
+                'profiles' => array(),
+            ),
+        );
+
+        $totalProfiles = 0;
+        foreach ($profiles as $profile) {
+            $kind = $profile['resource_kind'];
+            if (!isset($sections[$kind])) {
+                $sections[$kind] = array(
+                    'anchor' => 'residency-'.Tools::strtolower($kind),
+                    'title' => Tools::ucfirst($kind),
+                    'intro' => '',
+                    'profiles' => array(),
+                );
+            }
+
+            $displayName = $profile['resource_code'];
+            if (!empty($profile['story']['headline'])) {
+                $displayName = trim($profile['story']['headline']);
+            } elseif (!empty($profile['room_type_name'])) {
+                $displayName = $profile['room_type_name'];
+            }
+
+            $excerptSource = '';
+            if (!empty($profile['story']['excerpt'])) {
+                $excerptSource = $profile['story']['excerpt'];
+            } elseif (!empty($profile['story']['body'])) {
+                $excerptSource = $profile['story']['body'];
+            }
+            $excerptText = trim(strip_tags($excerptSource));
+            if ($excerptText !== '') {
+                $excerptText = Tools::truncate($excerptText, 220, '…');
+            }
+
+            $capacitySummary = array();
+            $capacity = $profile['capacity'];
+            if (!empty($capacity['total'])) {
+                if (!empty($capacity['adults']) && !empty($capacity['children'])) {
+                    $capacitySummary[] = $translator->trans(
+                        'Sleeps up to %total% guests (%adults% adults + %children% children).',
+                        array(
+                            '%total%' => $capacity['total'],
+                            '%adults%' => $capacity['adults'],
+                            '%children%' => $capacity['children'],
+                        ),
+                        'Modules.Hotelreservationsystem.Front'
+                    );
+                } else {
+                    $capacitySummary[] = $translator->trans(
+                        'Sleeps up to %total% guests.',
+                        array('%total%' => $capacity['total']),
+                        'Modules.Hotelreservationsystem.Front'
+                    );
+                }
+            } else {
+                if (!empty($capacity['adults'])) {
+                    $capacitySummary[] = $translator->trans(
+                        'Adults capacity: %count%',
+                        array('%count%' => $capacity['adults']),
+                        'Modules.Hotelreservationsystem.Front'
+                    );
+                }
+                if (!empty($capacity['children'])) {
+                    $capacitySummary[] = $translator->trans(
+                        'Children capacity: %count%',
+                        array('%count%' => $capacity['children']),
+                        'Modules.Hotelreservationsystem.Front'
+                    );
+                }
+            }
+
+            if (!empty($capacity['seated'])) {
+                $capacitySummary[] = $translator->trans(
+                    'Seated capacity: %count%',
+                    array('%count%' => $capacity['seated']),
+                    'Modules.Hotelreservationsystem.Front'
+                );
+            }
+            if (!empty($capacity['standing'])) {
+                $capacitySummary[] = $translator->trans(
+                    'Standing capacity: %count%',
+                    array('%count%' => $capacity['standing']),
+                    'Modules.Hotelreservationsystem.Front'
+                );
+            }
+            if (!empty($capacity['floor_area_sqm'])) {
+                $capacitySummary[] = $translator->trans(
+                    'Floor area: %sqm% m²',
+                    array('%sqm%' => Tools::ps_round($capacity['floor_area_sqm'], 2)),
+                    'Modules.Hotelreservationsystem.Front'
+                );
+            }
+            if (!empty($capacity['ceiling_height_m'])) {
+                $capacitySummary[] = $translator->trans(
+                    'Ceiling height: %height% m',
+                    array('%height%' => Tools::ps_round($capacity['ceiling_height_m'], 2)),
+                    'Modules.Hotelreservationsystem.Front'
+                );
+            }
+            if (!empty($profile['capacity_notes'])) {
+                $capacitySummary[] = Tools::truncate(trim(strip_tags($profile['capacity_notes'])), 180, '…');
+            }
+
+            if (!empty($profile['is_bookable'])) {
+                $capacitySummary[] = $translator->trans('Bookable directly on the occupancy timeline.', array(), 'Modules.Hotelreservationsystem.Front');
+            } else {
+                $capacitySummary[] = $translator->trans('Available on request via inquiry.', array(), 'Modules.Hotelreservationsystem.Front');
+            }
+
+            $sections[$kind]['profiles'][] = array(
+                'id' => $profile['id_kl_resource_profile'],
+                'resource_code' => $profile['resource_code'],
+                'display_name' => $displayName,
+                'room_type_name' => $profile['room_type_name'],
+                'excerpt' => $excerptText,
+                'capacity_summary' => $capacitySummary,
+                'timezone' => $profile['timezone'],
+            );
+            $totalProfiles++;
+        }
+
+        if ($totalProfiles === 0) {
+            return '';
+        }
+
+        $this->context->smarty->assign(array(
+            'residency_showcase' => array(
+                'sections' => $sections,
+            ),
+        ));
+
+        return $this->display(__FILE__, 'residency-home.tpl');
+    }
+
     public function cartBookingDataForMail($order)
     {
         $result = array();
@@ -626,6 +793,7 @@ class HotelReservationSystem extends Module
                 'actionCartSummary',
                 'actionFrontControllerSetMedia',
                 'displayExternalNavigationHook',
+                'displayHome',
             )
         );
     }

--- a/modules/hotelreservationsystem/views/templates/hook/residency-home.tpl
+++ b/modules/hotelreservationsystem/views/templates/hook/residency-home.tpl
@@ -1,0 +1,76 @@
+{*
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License version 3.0
+ * that is bundled with this package in the file LICENSE.md
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/license/osl-3-0-php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to support@qloapps.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to a newer
+ * versions in the future. If you wish to customize this module for your needs
+ * please refer to https://store.webkul.com/customisation-guidelines for more information.
+ *
+ * @author Webkul IN
+ * @copyright Since 2010 Webkul
+ * @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+ *}
+
+{if isset($residency_showcase.sections)}
+<section id="residency-showcase" class="residency-showcase">
+    <div class="container">
+        {foreach from=$residency_showcase.sections item=section}
+            <section id="{$section.anchor|escape:'html':'UTF-8'}" class="residency-section">
+                <header class="residency-section-header">
+                    <h2 class="residency-section-title">{$section.title|escape:'html':'UTF-8'}</h2>
+                    {if $section.intro}
+                        <p class="residency-section-intro">{$section.intro|escape:'html':'UTF-8'}</p>
+                    {/if}
+                </header>
+                {if isset($section.profiles) && $section.profiles}
+                    <div class="residency-card-grid">
+                        {foreach from=$section.profiles item=profile}
+                            <article class="residency-card" data-resource-code="{$profile.resource_code|escape:'html':'UTF-8'}">
+                                <header class="residency-card-header">
+                                    <h3 class="residency-card-title">{$profile.display_name|escape:'html':'UTF-8'}</h3>
+                                    {if $profile.room_type_name}
+                                        <p class="residency-card-subtitle">{$profile.room_type_name|escape:'html':'UTF-8'}</p>
+                                    {/if}
+                                </header>
+                                {if $profile.excerpt}
+                                    <p class="residency-card-excerpt">{$profile.excerpt|escape:'html':'UTF-8'}</p>
+                                {/if}
+                                {if $profile.capacity_summary}
+                                    <ul class="residency-card-meta">
+                                        {foreach from=$profile.capacity_summary item=item}
+                                            <li>{$item|escape:'html':'UTF-8'}</li>
+                                        {/foreach}
+                                    </ul>
+                                {/if}
+                                <footer class="residency-card-footer">
+                                    <span class="residency-card-code">
+                                        <strong>{l s='Resource code:' mod='hotelreservationsystem'}</strong>
+                                        {$profile.resource_code|escape:'html':'UTF-8'}
+                                    </span>
+                                    {if $profile.timezone}
+                                        <span class="residency-card-timezone">
+                                            <strong>{l s='Timezone:' mod='hotelreservationsystem'}</strong>
+                                            {$profile.timezone|escape:'html':'UTF-8'}
+                                        </span>
+                                    {/if}
+                                </footer>
+                            </article>
+                        {/foreach}
+                    </div>
+                {else}
+                    <p class="text-muted residency-section-empty">{l s='No resources published yet.' mod='hotelreservationsystem'}</p>
+                {/if}
+            </section>
+        {/foreach}
+    </div>
+</section>
+{/if}

--- a/modules/hotelreservationsystem/views/templates/hook/topPrimaryTaskBlock.tpl
+++ b/modules/hotelreservationsystem/views/templates/hook/topPrimaryTaskBlock.tpl
@@ -1,9 +1,9 @@
 <div class="col-xs-6 col-sm-5 col-md-4 pull-right padding-top-5">
     <div class="residency-top-actions">
         <ul class="list-unstyled residency-top-links">
-            <li><a class="residency-top-link" href="{$base_dir|escape:'html':'UTF-8'}#resident-services">{l s='Resident services' mod='hotelreservationsystem'}</a></li>
-            <li><a class="residency-top-link" href="{$base_dir|escape:'html':'UTF-8'}#wellness-calendar">{l s='Wellness calendar' mod='hotelreservationsystem'}</a></li>
-            <li><a class="residency-top-link" href="{$base_dir|escape:'html':'UTF-8'}#neighbourhood-guide">{l s='Neighbourhood guide' mod='hotelreservationsystem'}</a></li>
+            <li><a class="residency-top-link" href="{$base_dir|escape:'html':'UTF-8'}#residences-overview">{l s='Residences' mod='hotelreservationsystem'}</a></li>
+            <li><a class="residency-top-link" href="{$base_dir|escape:'html':'UTF-8'}#resident-ateliers">{l s='Studios & ateliers' mod='hotelreservationsystem'}</a></li>
+            <li><a class="residency-top-link" href="{$base_dir|escape:'html':'UTF-8'}#programme-spaces">{l s='Programme spaces' mod='hotelreservationsystem'}</a></li>
         </ul>
     </div>
 </div>

--- a/roadmap.md
+++ b/roadmap.md
@@ -16,7 +16,7 @@ This roadmap tracks how the Kunstort Lehnin fork evolves from a de-bloated QloAp
 ## Phase 2 – Resource & Pricing Model (🚧 In progress)
 - 🚧 **Resource taxonomy** – add `resource_kind`, capacity descriptors and amenities metadata to rooms, ateliers, seminar spaces and gastronomy units. The initial database tables plus matching `ObjectModel` classes now ship with the module install (see [`docs/blueprints/resource-taxonomy.md`](docs/blueprints/resource-taxonomy.md)). A back-office **Resource Profiles** tab now lets staff edit profile metadata and capacity descriptors; amenity/catalogue management and data migrations remain next.
 - ⏳ **Rate plans & packages** – introduce configurable price plans (BAR, corporate, residency programmes) plus bundled packages for weekly ateliers, catering-inclusive stays, etc., as laid out in [`docs/blueprints/rate-plans-packages.md`](docs/blueprints/rate-plans-packages.md).
-- ⏳ **Frontend storytelling** – rebuild offer pages to surface the new taxonomy with curated copy, imagery and availability cues informed by the taxonomy and packages.
+- 🚧 **Frontend storytelling** – the home page now surfaces published resource profiles with capacity cues; next steps extend storytelling and imagery to offer detail pages informed by taxonomy and packages.
 
 ## Phase 3 – Operations Automation (⏳ Planned)
 - ⏳ **Housekeeping & maintenance tasks** – auto-generate cleaning and technical checklists from arrival/departure data and allow staff to report statuses (clean, in progress, needs repair). Architectural notes live in [`docs/blueprints/operations-automation.md`](docs/blueprints/operations-automation.md).

--- a/themes/hotel-reservation-theme/css/global.css
+++ b/themes/hotel-reservation-theme/css/global.css
@@ -9290,3 +9290,114 @@ div a.our_properties_link{
     margin-left: 0;
   }
 }
+
+.residency-showcase {
+  padding: 60px 0;
+  background-color: #f7f4ef;
+}
+
+.residency-section + .residency-section {
+  margin-top: 60px;
+}
+
+.residency-section-header {
+  margin-bottom: 25px;
+}
+
+.residency-section-title {
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #3c3426;
+  margin-bottom: 10px;
+}
+
+.residency-section-intro {
+  font-size: 16px;
+  color: #5e5549;
+  max-width: 760px;
+}
+
+.residency-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.residency-card {
+  background-color: #fff;
+  border-radius: 8px;
+  border: 1px solid rgba(60, 52, 38, 0.08);
+  box-shadow: 0 8px 24px rgba(12, 6, 0, 0.08);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.residency-card-header {
+  margin-bottom: 16px;
+}
+
+.residency-card-title {
+  font-size: 20px;
+  color: #312a1e;
+  margin: 0 0 4px;
+}
+
+.residency-card-subtitle {
+  color: #847a6c;
+  font-size: 14px;
+  margin: 0;
+}
+
+.residency-card-excerpt {
+  color: #4d4538;
+  margin-bottom: 16px;
+  line-height: 1.5;
+  flex-grow: 1;
+}
+
+.residency-card-meta {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px;
+  color: #5e5549;
+  font-size: 14px;
+}
+
+.residency-card-meta li + li {
+  margin-top: 6px;
+}
+
+.residency-card-footer {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 13px;
+  color: #756b5c;
+}
+
+.residency-card-code strong,
+.residency-card-timezone strong {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  margin-right: 6px;
+  color: #a1844c;
+}
+
+.residency-section-empty {
+  font-size: 15px;
+}
+
+@media (max-width: 767px) {
+  .residency-section-title {
+    font-size: 20px;
+  }
+
+  .residency-card {
+    padding: 20px;
+  }
+}

--- a/themes/hotel-reservation-theme/header.tpl
+++ b/themes/hotel-reservation-theme/header.tpl
@@ -105,10 +105,9 @@
                                                                                 <nav class="residency-primary-nav" role="navigation" aria-label="{l s='Residency primary navigation'}">
                                                                                         <ul class="nav nav-pills nav-justified">
                                                                                                 <li><a href="{$base_dir|escape:'html':'UTF-8'}#residences-overview">{l s='Residences'}</a></li>
-                                                                                                <li><a href="{$base_dir|escape:'html':'UTF-8'}#extended-stays">{l s='Long stays'}</a></li>
-                                                                                                <li><a href="{$base_dir|escape:'html':'UTF-8'}#amenities">{l s='Amenities'}</a></li>
-                                                                                                <li><a href="{$base_dir|escape:'html':'UTF-8'}#dining">{l s='Dining'}</a></li>
-                                                                                                <li><a href="{$base_dir|escape:'html':'UTF-8'}#experiences">{l s='Experiences'}</a></li>
+                                                                                                <li><a href="{$base_dir|escape:'html':'UTF-8'}#resident-ateliers">{l s='Studios & ateliers'}</a></li>
+                                                                                                <li><a href="{$base_dir|escape:'html':'UTF-8'}#dining">{l s='Dining & gastronomy'}</a></li>
+                                                                                                <li><a href="{$base_dir|escape:'html':'UTF-8'}#programme-spaces">{l s='Programme spaces'}</a></li>
                                                                                                 <li><a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='Contact'}</a></li>
                                                                                         </ul>
                                                                                 </nav>
@@ -149,7 +148,7 @@
                                                                                         </div>
                                                                                         <div class="residency-quick-actions">
                                                                                                 <a class="our_properties_link" href="{$link->getPageLink('our-properties')}" title="{l s='Explore all residences'}">{l s='Our Residences'}</a>
-                                                                                                <a class="our_properties_link" href="{$base_dir|escape:'html':'UTF-8'}#resident-services" title="{l s='Resident services'}">{l s='Resident Services'}</a>
+                                                                                                <a class="our_properties_link" href="{$base_dir|escape:'html':'UTF-8'}#resident-ateliers" title="{l s='Studios & ateliers'}">{l s='Studios & ateliers'}</a>
                                                                                         </div>
                                                                                 </div>
                                                                         </div>


### PR DESCRIPTION
## Summary
- expose published resource profiles with storytelling details via a new `hookDisplayHome` showcase
- add helper retrieval on `KLResourceProfile` and a Smarty template to render capacity-rich residency cards
- refresh theme navigation, quick links, and documentation to reflect the real resource-driven sections

## Testing
- php -l modules/hotelreservationsystem/classes/KLResourceProfile.php
- php -l modules/hotelreservationsystem/hotelreservationsystem.php

------
https://chatgpt.com/codex/tasks/task_e_68d3e3b3d4248321982fa267c74390dc