### PR TITLE
Add development bootstrap script for quick local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Increase PHP limits for development (memory ≥ 256M, max_execution_time ≥ 300
 3. Make sure `config/defines_custom.inc.php` is loaded (it is included automatically) so that marketplace integrations remain disabled.
 4. Run the classic QloApps installer by visiting `/install` in your browser, or migrate an existing database.
 
+### Quickstart script
+
+For day-to-day development run:
+
+```bash
+./start_dev.sh
+```
+
+The helper script creates (or reuses) a local Python virtual environment at `.venv`, installs Composer dependencies, warns if the application still needs to be installed, and finally starts the PHP built-in server on `http://127.0.0.1:8000`. Override the host or port by exporting `HOST`/`PORT` before executing the script.
+
 After installation you can log into the admin back office at `/admin` (rename the directory for security). The module catalogue will no longer attempt to connect to external stores; only locally available modules are listed.
 
 ## Distribution Flags

--- a/checklist.md
+++ b/checklist.md
@@ -11,6 +11,7 @@
 - [x] Retired the legacy PrestaShop webservice (dispatcher now returns 410, admin tab removed, classes stubbed).
 - [x] Removed legacy bank wire, cheque and PayPal Commerce payment modules plus their theme overrides.
 - [x] Modeled a dedicated Inquiry entity plus Kanban board with reminders, assignments and mail notes that email guests when flagged.
+- [x] Added `start_dev.sh` to bootstrap Composer, Python tooling and the PHP dev server for local testing.
 
 ## In Progress
 - [ ] Draft resource taxonomy for rooms, ateliers, gastronomy areas.

--- a/concept.md
+++ b/concept.md
@@ -24,6 +24,7 @@ Create a lean, fully self-hosted hospitality operations tool tailored to Kunstor
 - The front-office header ships as a static residency navigation strip with in-house quick links; cart/account/newsletter/social blocks have been removed from both the theme and core module set so no commerce widgets are expected.
 - The front-office home page now surfaces a residency showcase fed by published resource profiles so rooms, ateliers, gastronomy and programme spaces display live metadata instead of mockups.
 - Legacy PrestaShop webservice entry points are stubbed; `/webservice` responds with HTTP 410 and no admin UI exposes API keys.
+- A repo-level `start_dev.sh` script provisions a Python virtualenv for tooling, keeps Composer dependencies current, and boots the PHP built-in server for local testing.
 
 ## Inquiry Workflow Additions
 - A dedicated Inquiry entity tracks residency requests independently from carts, including assignee, reminder, and note metadata.

--- a/roadmap.md
+++ b/roadmap.md
@@ -12,6 +12,7 @@ This roadmap tracks how the Kunstort Lehnin fork evolves from a de-bloated QloAp
 - ✅ **Timeline interaction upgrades** – add drag-and-drop reallocation with conflict detection against room disables and capacity rules.
 - ✅ **Inquiry entity & board** – replace cart-derived booking scaffolding with a dedicated Inquiry model, Kanban board UI and assignment workflow, including reminders and guest-facing mail notes from the board.
 - ✅ **API endpoints** – expose REST endpoints for timeline updates, inquiry status changes and availability lookups to support the new UI components.
+- ✅ **Dev bootstrap helper** – ship `start_dev.sh` to keep Composer dependencies fresh, prep Python tooling via `.venv`, and launch the PHP dev server for quick smoke testing.
 
 ## Phase 2 – Resource & Pricing Model (🚧 In progress)
 - 🚧 **Resource taxonomy** – add `resource_kind`, capacity descriptors and amenities metadata to rooms, ateliers, seminar spaces and gastronomy units. The initial database tables plus matching `ObjectModel` classes now ship with the module install (see [`docs/blueprints/resource-taxonomy.md`](docs/blueprints/resource-taxonomy.md)). A back-office **Resource Profiles** tab now lets staff edit profile metadata and capacity descriptors; amenity/catalogue management and data migrations remain next.

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine project root relative to this script
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$PROJECT_ROOT/.venv"
+
+info() {
+  printf '\e[34m[INFO]\e[0m %s\n' "$*"
+}
+
+warn() {
+  printf '\e[33m[WARN]\e[0m %s\n' "$*" >&2
+}
+
+error() {
+  printf '\e[31m[ERROR]\e[0m %s\n' "$*" >&2
+}
+
+ensure_python_venv() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    error "python3 is required to create a virtual environment."
+    exit 1
+  fi
+
+  if [[ ! -d "$VENV_DIR" ]]; then
+    info "Creating Python virtual environment under $VENV_DIR"
+    python3 -m venv "$VENV_DIR"
+  else
+    info "Using existing Python virtual environment at $VENV_DIR"
+  fi
+
+  # shellcheck disable=SC1090
+  source "$VENV_DIR/bin/activate"
+  python -m pip install --upgrade pip wheel setuptools >/dev/null
+
+  local requirements_file="$PROJECT_ROOT/requirements-dev.txt"
+  if [[ -f "$requirements_file" ]]; then
+    info "Installing Python development dependencies from requirements-dev.txt"
+    pip install -r "$requirements_file"
+  fi
+}
+
+ensure_php_dependencies() {
+  if command -v composer >/dev/null 2>&1; then
+    info "Installing PHP dependencies with composer"
+    composer install --no-interaction --prefer-dist --working-dir="$PROJECT_ROOT"
+  else
+    warn "Composer not found. Skipping PHP dependency installation. Install Composer to manage PHP packages."
+  fi
+}
+
+check_application_config() {
+  local settings_file="$PROJECT_ROOT/config/settings.inc.php"
+  if [[ ! -f "$settings_file" ]]; then
+    warn "config/settings.inc.php is missing. Run the installer via /install before using the application."
+  fi
+}
+
+start_php_server() {
+  local host="${HOST:-127.0.0.1}"
+  local port="${PORT:-8000}"
+  local router="$PROJECT_ROOT/tools/dev-router.php"
+
+  if ! command -v php >/dev/null 2>&1; then
+    error "php is required to run the development server."
+    exit 1
+  fi
+
+  if [[ ! -f "$router" ]]; then
+    error "Expected router script $router not found."
+    exit 1
+  fi
+
+  info "Starting PHP development server at http://$host:$port"
+  info "Press Ctrl+C to stop the server."
+  cd "$PROJECT_ROOT"
+  exec php -S "$host:$port" -t "$PROJECT_ROOT" "$router"
+}
+
+ensure_python_venv
+ensure_php_dependencies
+check_application_config
+start_php_server

--- a/tools/dev-router.php
+++ b/tools/dev-router.php
@@ -1,0 +1,18 @@
+<?php
+$projectRoot = realpath(__DIR__ . '/..');
+$requestUri = $_SERVER['REQUEST_URI'] ?? '/';
+$parsedPath = parse_url($requestUri, PHP_URL_PATH) ?: '/';
+$filePath = realpath($projectRoot . $parsedPath);
+
+if ($filePath !== false && str_starts_with($filePath, $projectRoot) && is_file($filePath)) {
+    return false; // Serve the requested resource as-is.
+}
+
+// Route admin traffic if the directory hasn't been renamed yet.
+if (preg_match('#^/admin(/.*)?$#', $parsedPath) && is_file($projectRoot . '/admin/index.php')) {
+    require $projectRoot . '/admin/index.php';
+    return true;
+}
+
+require $projectRoot . '/index.php';
+return true;


### PR DESCRIPTION
## Summary
- add a start_dev.sh helper that provisions a Python virtualenv, installs Composer dependencies and launches the PHP dev server
- provide a PHP router for the built-in server so dynamic routes reach the correct front or back office entry points
- document the bootstrap flow across the README, concept, checklist and roadmap to reflect the new workflow

## Testing
- bash -n start_dev.sh
- php -l tools/dev-router.php

------
https://chatgpt.com/codex/tasks/task_e_68d4113bb3b88321b16046805c4ed198