### PR TITLE
Restore checkout controllers and guard inquiry mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Key characteristics of the fork:
 - 🚫 **Marketplace free** – outbound calls to the QloApps / Prestashop module stores are disabled by default.
 - 🧩 **Extensible from source** – custom modules can still be developed and dropped into `modules/` without depending on proprietary services.
 - 📆 **Calendar first** – the admin booking view now opens on a resource timeline covering rooms, ateliers, seminar rooms and programme spaces, with the legacy month grid available on demand.
-- 📨 **Inquiry workflow** – the legacy checkout paths now forward to an inquiry landing page so staff can confirm curated requests manually.
+- 📨 **Inquiry workflow** – when inquiry mode is enabled, the legacy checkout paths forward to an inquiry landing page so staff can confirm curated requests manually, while cart-driven checkout remains available when the flag is disabled.
 - 🔌 **Offline-friendly admin** – the Addons and Theme catalogues show local installation guidance instead of remote marketplace iframes.
 - 🧭 **Residency navigation** – the front-office header ships with a static residency nav bar and in-house quick links; cart/account/newsletter/social blocks have been excised from both the theme overrides and the module set.
 - 🗺️ **Resource showcase** – the home page now renders a residency showcase fed by published resource profiles so rooms, studios, gastronomy and programme spaces surface real capacity and availability cues.
@@ -29,7 +29,9 @@ The high-level concept lives in [`concept.md`](concept.md), the multi-phase plan
 
 ### Inquiry Landing
 
-Visiting `/index.php?controller=inquiry` (or any deprecated checkout URL such as `/index.php?controller=order`) shows a lightweight landing page that explains the new manual workflow and links to the contact form until the dedicated inquiry UI ships.
+Visiting `/index.php?controller=inquiry` always shows a lightweight landing page that explains the new manual workflow and links to the contact form until the dedicated inquiry UI ships. When `_KUNSTORT_CORE_MODE_` equals `inquiry`, legacy checkout URLs such as `/index.php?controller=order` redirect here instead of exposing cart mechanics, but the original order and one-page-checkout controllers/templates remain in place so clearing the flag instantly restores the classic flow.
+
+While inquiry mode is active the cart controller refuses to mutate cart contents—direct requests receive an error (or redirect to the inquiry landing) so ghost carts cannot accumulate behind the scenes—and any AJAX checkout calls now short-circuit with a friendly JSON error explaining that checkout is disabled.
 
 ### Legacy PrestaShop Webservice
 
@@ -108,7 +110,7 @@ For day-to-day development run:
 ./start_dev.sh
 ```
 
-The helper script creates (or reuses) a local Python virtual environment at `.venv`, installs Composer dependencies, warns if the application still needs to be installed, and finally starts the PHP built-in server on `http://127.0.0.1:8000`. Override the host or port by exporting `HOST`/`PORT` before executing the script.
+The helper script creates (or reuses) a local Python virtual environment at `.venv`, installs Composer dependencies, warns if the application still needs to be installed, and finally starts the PHP built-in server on `http://127.0.0.1:8000`. Override the host or port by exporting `HOST`/`PORT` before executing the script. The bundled development router stays compatible with PHP 7.4+, so the server can run on environments that have not yet upgraded to PHP 8.
 
 After installation you can log into the admin back office at `/admin` (rename the directory for security). The module catalogue will no longer attempt to connect to external stores; only locally available modules are listed.
 

--- a/checklist.md
+++ b/checklist.md
@@ -6,7 +6,9 @@
 - [x] Replaced marketplace catalog UIs with offline guidance when remote services are disabled.
 - [x] Replaced the admin booking calendar with a tabbed occupancy timeline and lazy-loaded month grid fallback.
 - [x] Cached admin booking timeline data to keep tab switches instantaneous.
-- [x] Short-circuited checkout routes and templates to the inquiry landing page.
+- [x] Short-circuited checkout routes and templates to the inquiry landing page whenever inquiry mode is enabled, while keeping the cart workflow available when the flag is cleared.
+- [x] Restored the full legacy order and one-page-checkout controllers/templates so disabling inquiry mode instantly re-enables checkout, with inquiry-mode requests returning friendly redirects or JSON errors.
+- [x] Blocked cart controller mutations while inquiry mode is active to prevent ghost carts.
 - [x] Replaced hook-driven header widgets with a static residency navigation and removed cart/account/newsletter/social modules from the codebase.
 - [x] Retired the legacy PrestaShop webservice (dispatcher now returns 410, admin tab removed, classes stubbed).
 - [x] Removed legacy bank wire, cheque and PayPal Commerce payment modules plus their theme overrides.

--- a/concept.md
+++ b/concept.md
@@ -15,7 +15,8 @@ Create a lean, fully self-hosted hospitality operations tool tailored to Kunstor
 - Admin module catalogue interactions are short-circuited to keep the back office free from external promotions.
 - `config/defines_custom.inc.php` houses feature flags for the Kunstort distribution (e.g. `_KUNSTORT_CORE_MODE_ = 'inquiry'`).
 - Legacy offline payment modules (bank wire, cheque) and the PayPal Commerce gateway have been removed to keep the stack focused on inquiry-driven fulfilment.
-- When `_KUNSTORT_CORE_MODE_` is set to `inquiry`, the legacy checkout controllers and templates short-circuit to the inquiry landing page instead of exposing cart mechanics.
+- When `_KUNSTORT_CORE_MODE_` is set to `inquiry`, the legacy checkout controllers short-circuit to the inquiry landing page (and AJAX calls return friendly errors) instead of exposing cart mechanics, while the full cart-first flow immediately returns once the flag is cleared.
+- Inquiry mode now also blocks the cart controller from mutating cart contents so direct requests cannot create ghost carts behind the scenes, and the original checkout templates/controllers remain intact for instant fallback.
 - When marketplace access is disabled, admin catalogue and theme pages display offline guidance instead of loading remote iframes.
 - The admin booking screen now opens with a tabbed occupancy timeline; the legacy month grid loads lazily only when the calendar tab is selected, and timeline data stays cached while the tab remains active for near-instant toggling.
 - Drag-and-drop reallocation is available directly on the occupancy timeline with server-side conflict checks against disabled rooms and capacity limits.

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -68,6 +68,19 @@ class CartControllerCore extends FrontController
 
     public function postProcess()
     {
+        if ($this->isInquiryMode()) {
+            if (Tools::getValue('ajax')) {
+                $this->ajaxDie(json_encode(array(
+                    'hasError' => true,
+                    'errors' => array(Tools::displayError('Cart actions are disabled while inquiry mode is active.')),
+                )));
+            }
+
+            Tools::redirect($this->context->link->getPageLink('inquiry', true));
+
+            return;
+        }
+
         // Update the cart ONLY if $this->cookies are available, in order to avoid ghost carts created by bots
         if ($this->context->cookie->exists() && !$this->errors && !($this->context->customer->isLogged() && !$this->isTokenValid())) {
             if (Tools::getIsset('add') || Tools::getIsset('update')) {
@@ -117,6 +130,11 @@ class CartControllerCore extends FrontController
                 Tools::redirect('index.php');
             }
         }
+    }
+
+    protected function isInquiryMode()
+    {
+        return defined('_KUNSTORT_CORE_MODE_') && _KUNSTORT_CORE_MODE_ === 'inquiry';
     }
 
     /**

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -1,5 +1,483 @@
 <?php
+/*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
 
 class OrderControllerCore extends ParentOrderController
 {
+    public $step;
+    const STEP_SUMMARY_EMPTY_CART = -1;
+    const STEP_ADDRESSES = 1;
+    const STEP_DELIVERY = 2;
+    const STEP_PAYMENT = 3;
+
+    /**
+     * Initialize order controller
+     * @see FrontController::init()
+     */
+    public function init()
+    {
+        global $orderTotal;
+
+        parent::init();
+
+        $this->step = (int)Tools::getValue('step');
+        if (!$this->nbProducts) {
+            $this->step = -1;
+        }
+
+        $product = $this->context->cart->checkQuantities(true);
+
+        if ((int)$id_product = $this->context->cart->checkProductsAccess()) {
+            $this->step = 0;
+            $this->errors[] = sprintf(Tools::displayError('An item in your cart is no longer available (%1s). You cannot proceed with your order.'), Product::getProductName((int)$id_product));
+        }
+
+        // If some products have disappear
+        if (is_array($product)) {
+            $this->step = 0;
+            $this->errors[] = sprintf(Tools::displayError('An item (%1s) in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.'), $product['name']);
+        }
+
+        // Check minimal amount
+        $currency = Currency::getCurrency((int)$this->context->cart->id_currency);
+
+        $orderTotal = $this->context->cart->getOrderTotal();
+        $minimal_purchase = Tools::convertPrice((float)Configuration::get('PS_PURCHASE_MINIMUM'), $currency);
+        if ($this->context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS) < $minimal_purchase && $this->step > 0) {
+            $_GET['step'] = $this->step = 0;
+            $this->errors[] = sprintf(
+                Tools::displayError('A minimum purchase total of %1s (tax excl.) is required to validate your order, current purchase total is %2s (tax excl.).'),
+                Tools::displayPrice($minimal_purchase, $currency), Tools::displayPrice($this->context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS), $currency)
+            );
+        }
+        if (!$this->context->customer->isLogged(true) && in_array($this->step, array(1, 2, 3))) {
+            $params = array();
+            if ($this->step) {
+                $params['step'] = (int)$this->step;
+            }
+            if ($multi = (int)Tools::getValue('multi-shipping')) {
+                $params['multi-shipping'] = $multi;
+            }
+
+            $back_url = $this->context->link->getPageLink('order', true, (int)$this->context->language->id, $params);
+
+            $params = array('back' => $back_url);
+            if ($multi) {
+                $params['multi-shipping'] = $multi;
+            }
+            if ($guest = (int)Configuration::get('PS_GUEST_CHECKOUT_ENABLED')) {
+                $params['display_guest_checkout'] = $guest;
+            }
+
+            Tools::redirect($this->context->link->getPageLink('authentication', true, (int)$this->context->language->id, $params));
+        }
+
+        if (Tools::getValue('multi-shipping') == 1) {
+            $this->context->smarty->assign('multi_shipping', true);
+        } else {
+            $this->context->smarty->assign('multi_shipping', false);
+        }
+
+        if ($this->context->customer->id) {
+            $this->context->smarty->assign('address_list', $this->context->customer->getAddresses($this->context->language->id));
+        } else {
+            $this->context->smarty->assign('address_list', array());
+        }
+    }
+
+    public function postProcess()
+    {
+        // Update carrier selected on preProccess in order to fix a bug of
+        // block cart when it's hooked on leftcolumn
+        if ($this->step == 3 && Tools::isSubmit('processCarrier')) {
+            $this->processCarrier();
+        }
+    }
+
+    /**
+     * Assign template vars related to page content
+     * @see FrontController::initContent()
+     */
+    public function initContent()
+    {
+        parent::initContent();
+
+        if ($this->isInquiryMode()) {
+            return;
+        }
+
+        if (Tools::isSubmit('ajax') && Tools::getValue('method') == 'updateExtraCarrier') {
+            // Change virtualy the currents delivery options
+            $delivery_option = $this->context->cart->getDeliveryOption();
+            $delivery_option[(int)Tools::getValue('id_address')] = Tools::getValue('id_delivery_option');
+            $this->context->cart->setDeliveryOption($delivery_option);
+            $this->context->cart->save();
+            $return = array(
+                'content' => Hook::exec(
+                    'displayCarrierList',
+                    array(
+                        'address' => new Address((int)Tools::getValue('id_address'))
+                    )
+                )
+            );
+            $this->ajaxDie(json_encode($return));
+        }
+
+        if ($this->nbProducts) {
+            $this->context->smarty->assign('virtual_cart', $this->context->cart->isVirtualCart());
+        }
+
+        if (!Tools::getValue('multi-shipping')) {
+            $this->context->cart->setNoMultishipping();
+        }
+
+        // Check for alternative payment api
+        $is_advanced_payment_api = (bool)Configuration::get('PS_ADVANCED_PAYMENT_API');
+
+        // 4 steps to the order
+        switch ((int)$this->step) {
+
+            case OrderController::STEP_SUMMARY_EMPTY_CART:
+                $this->context->smarty->assign('empty', 1);
+                $this->setTemplate(_PS_THEME_DIR_.'shopping-cart.tpl');
+            break;
+
+            case OrderController::STEP_ADDRESSES:
+                $this->_assignAddress();
+                $this->processAddressFormat();
+                if (Tools::getValue('multi-shipping') == 1) {
+                    $this->_assignSummaryInformations();
+                    $this->context->smarty->assign('product_list', $this->context->cart->getProducts());
+                    $this->setTemplate(_PS_THEME_DIR_.'order-address-multishipping.tpl');
+                } else {
+                    $this->setTemplate(_PS_THEME_DIR_.'order-address.tpl');
+                }
+            break;
+
+            case OrderController::STEP_DELIVERY:
+                if (Tools::isSubmit('processAddress')) {
+                    $this->processAddress();
+                }
+                $this->autoStep();
+                $this->_assignCarrier();
+                $this->setTemplate(_PS_THEME_DIR_.'order-carrier.tpl');
+            break;
+
+            case OrderController::STEP_PAYMENT:
+                // Check that the conditions (so active) were accepted by the customer
+                $cgv = Tools::getValue('cgv') || $this->context->cookie->check_cgv;
+
+                if ($is_advanced_payment_api === false && Configuration::get('PS_CONDITIONS')
+                    && (!Validate::isBool($cgv) || $cgv == false)) {
+                    Tools::redirect('index.php?controller=order&step=2');
+                }
+
+                if ($is_advanced_payment_api === false) {
+                    Context::getContext()->cookie->check_cgv = true;
+                }
+
+                // Check the delivery option is set
+                if ($this->context->cart->isVirtualCart() === false) {
+                    if (!Tools::getValue('delivery_option') && !Tools::getValue('id_carrier') && !$this->context->cart->delivery_option && !$this->context->cart->id_carrier) {
+                        Tools::redirect('index.php?controller=order&step=2');
+                    } elseif (!Tools::getValue('id_carrier') && !$this->context->cart->id_carrier) {
+                        $deliveries_options = Tools::getValue('delivery_option');
+                        if (!$deliveries_options) {
+                            $deliveries_options = $this->context->cart->delivery_option;
+                        }
+
+                        foreach ($deliveries_options as $delivery_option) {
+                            if (empty($delivery_option)) {
+                                Tools::redirect('index.php?controller=order&step=2');
+                            }
+                        }
+                    }
+                }
+
+                $this->autoStep();
+
+                // Bypass payment step if total is 0
+                if (($id_order = $this->_checkFreeOrder()) && $id_order) {
+                    if ($this->context->customer->is_guest) {
+                        $order = new Order((int)$id_order);
+                        $email = $this->context->customer->email;
+                        $this->context->customer->mylogout(); // If guest we clear the cookie for security reason
+                        Tools::redirect('index.php?controller=guest-tracking&id_order='.urlencode($order->reference).'&email='.urlencode($email));
+                    } else {
+                        Tools::redirect('index.php?controller=history');
+                    }
+                }
+                $this->_assignPayment();
+
+                if ($is_advanced_payment_api === true) {
+                    $this->_assignAddress();
+                }
+
+                // assign some informations to display cart
+                $this->_assignSummaryInformations();
+                $this->setTemplate(_PS_THEME_DIR_.'order-payment.tpl');
+            break;
+
+            default:
+                $this->_assignSummaryInformations();
+                $this->setTemplate(_PS_THEME_DIR_.'shopping-cart.tpl');
+            break;
+        }
+    }
+
+    protected function processAddressFormat()
+    {
+        $addressDelivery = new Address((int)$this->context->cart->id_address_delivery);
+        $addressInvoice = new Address((int)$this->context->cart->id_address_invoice);
+
+        $invoiceAddressFields = AddressFormat::getOrderedAddressFields($addressInvoice->id_country, false, true);
+        $deliveryAddressFields = AddressFormat::getOrderedAddressFields($addressDelivery->id_country, false, true);
+
+        $this->context->smarty->assign(array(
+            'inv_adr_fields' => $invoiceAddressFields,
+            'dlv_adr_fields' => $deliveryAddressFields));
+    }
+
+    /**
+     * Order process controller
+     */
+    public function autoStep()
+    {
+        if ($this->step >= 2 && (!$this->context->cart->id_address_delivery || !$this->context->cart->id_address_invoice)) {
+            Tools::redirect('index.php?controller=order&step=1');
+        }
+
+        if ($this->step > 2 && !$this->context->cart->isVirtualCart()) {
+            $redirect = false;
+            if (count($this->context->cart->getDeliveryOptionList()) == 0) {
+                $redirect = true;
+            }
+
+            $delivery_option = $this->context->cart->getDeliveryOption();
+            if (is_array($delivery_option)) {
+                $carrier = explode(',', $delivery_option[(int)$this->context->cart->id_address_delivery]);
+            }
+
+            if (!$redirect && !$this->context->cart->isMultiAddressDelivery()) {
+                foreach ($this->context->cart->getProducts() as $product) {
+                    $carrier_list = Carrier::getAvailableCarrierList(new Product($product['id_product']), null, $this->context->cart->id_address_delivery);
+                    foreach ($carrier as $id_carrier) {
+                        if (!in_array($id_carrier, $carrier_list)) {
+                            $redirect = true;
+                        } else {
+                            $redirect = false;
+                            break;
+                        }
+                    }
+                    if ($redirect) {
+                        break;
+                    }
+                }
+            }
+
+            if ($redirect) {
+                Tools::redirect('index.php?controller=order&step=2');
+            }
+        }
+
+        $delivery = new Address((int)$this->context->cart->id_address_delivery);
+        $invoice = new Address((int)$this->context->cart->id_address_invoice);
+
+        if ($delivery->deleted || $invoice->deleted) {
+            if ($delivery->deleted) {
+                unset($this->context->cart->id_address_delivery);
+            }
+            if ($invoice->deleted) {
+                unset($this->context->cart->id_address_invoice);
+            }
+            Tools::redirect('index.php?controller=order&step=1');
+        }
+    }
+
+    /**
+     * Manage address
+     */
+    public function processAddress()
+    {
+        $same = Tools::isSubmit('same');
+        if (!Tools::getValue('id_address_invoice', false) && !$same) {
+            $same = true;
+        }
+
+        if (!Customer::customerHasAddress($this->context->customer->id, (int)Tools::getValue('id_address_delivery'))
+            || (!$same && Tools::getValue('id_address_delivery') != Tools::getValue('id_address_invoice')
+                && !Customer::customerHasAddress($this->context->customer->id, (int)Tools::getValue('id_address_invoice')))) {
+            $this->errors[] = Tools::displayError('Invalid address', !Tools::getValue('ajax'));
+        } else {
+            $this->context->cart->id_address_delivery = (int)Tools::getValue('id_address_delivery');
+            $this->context->cart->id_address_invoice = $same ? $this->context->cart->id_address_delivery : (int)Tools::getValue('id_address_invoice');
+
+            CartRule::autoRemoveFromCart($this->context);
+            CartRule::autoAddToCart($this->context);
+
+            if (!$this->context->cart->update()) {
+                $this->errors[] = Tools::displayError('An error occurred while updating your cart.', !Tools::getValue('ajax'));
+            }
+
+            if (!$this->context->cart->isMultiAddressDelivery()) {
+                $this->context->cart->setNoMultishipping();
+            } // If there is only one delivery address, set each delivery address lines with the main delivery address
+
+            if (Tools::isSubmit('message')) {
+                $this->_updateMessage(Tools::getValue('message'));
+            }
+
+            // Add checking for all addresses
+            $errors = array();
+            $address_without_carriers = $this->context->cart->getDeliveryAddressesWithoutCarriers(false, $errors);
+            if (count($address_without_carriers) && !$this->context->cart->isVirtualCart()) {
+                $flag_error_message = false;
+                foreach ($errors as $error) {
+                    if ($error == Carrier::SHIPPING_WEIGHT_EXCEPTION && !$flag_error_message) {
+                        $this->errors[] = sprintf(Tools::displayError('The product selection cannot be delivered by the available carrier(s): it is too heavy. Please amend your cart to lower its weight.', !Tools::getValue('ajax')));
+                        $flag_error_message = true;
+                    } elseif ($error == Carrier::SHIPPING_PRICE_EXCEPTION && !$flag_error_message) {
+                        $this->errors[] = sprintf(Tools::displayError('The product selection cannot be delivered by the available carrier(s). Please amend your cart.', !Tools::getValue('ajax')));
+                        $flag_error_message = true;
+                    } elseif ($error == Carrier::SHIPPING_SIZE_EXCEPTION && !$flag_error_message) {
+                        $this->errors[] = sprintf(Tools::displayError('The product selection cannot be delivered by the available carrier(s): its size does not fit. Please amend your cart to reduce its size.', !Tools::getValue('ajax')));
+                        $flag_error_message = true;
+                    }
+                }
+                if (count($address_without_carriers) > 1 && !$flag_error_message) {
+                    $this->errors[] = sprintf(Tools::displayError('There are no carriers that deliver to some addresses you selected.', !Tools::getValue('ajax')));
+                } elseif ($this->context->cart->isMultiAddressDelivery() && !$flag_error_message) {
+                    $this->errors[] = sprintf(Tools::displayError('There are no carriers that deliver to one of the address you selected.', !Tools::getValue('ajax')));
+                } elseif (!$flag_error_message) {
+                    $this->errors[] = sprintf(Tools::displayError('There are no carriers that deliver to the address you selected.', !Tools::getValue('ajax')));
+                }
+            }
+        }
+
+        if ($this->errors) {
+            if (Tools::getValue('ajax')) {
+                $this->ajaxDie('{"hasError" : true, "errors" : ["'.implode('\',\'', $this->errors).'"]}');
+            }
+            $this->step = 1;
+        }
+
+        if ($this->ajax) {
+            $this->ajaxDie(true);
+        }
+    }
+
+    /**
+     * Carrier step
+     */
+    protected function processCarrier()
+    {
+        global $orderTotal;
+        parent::_processCarrier();
+
+        if (count($this->errors)) {
+            $this->context->smarty->assign('errors', $this->errors);
+            $this->_assignCarrier();
+            $this->step = 2;
+            $this->displayContent();
+        }
+        $orderTotal = $this->context->cart->getOrderTotal();
+    }
+
+    /**
+     * Address step
+     */
+    protected function _assignAddress()
+    {
+        parent::_assignAddress();
+
+        if (Tools::getValue('multi-shipping')) {
+            $this->context->cart->autosetProductAddress();
+        }
+
+        $this->context->smarty->assign('cart', $this->context->cart);
+    }
+
+    /**
+     * Carrier step
+     */
+    protected function _assignCarrier()
+    {
+        if (!isset($this->context->customer->id)) {
+            die(Tools::displayError('Fatal error: No customer'));
+        }
+        // Assign carrier
+        parent::_assignCarrier();
+        // Assign wrapping and TOS
+        $this->_assignWrappingAndTOS();
+
+        $this->context->smarty->assign(
+            array(
+                'is_guest' => (isset($this->context->customer->is_guest) ? $this->context->customer->is_guest : 0)
+            ));
+    }
+
+    /**
+     * Payment step
+     */
+    protected function _assignPayment()
+    {
+        global $orderTotal;
+
+        // Redirect instead of displaying payment modules if any module are grefted on
+        Hook::exec('displayBeforePayment', array('module' => 'order.php?step=3'));
+
+        /* We may need to display an order summary */
+        $this->context->smarty->assign($this->context->cart->getSummaryDetails());
+
+        if ((bool)Configuration::get('PS_ADVANCED_PAYMENT_API')) {
+            $this->context->cart->checkedTOS = null;
+        } else {
+            $this->context->cart->checkedTOS = 1;
+        }
+
+        // Test if we have to override TOS display through hook
+        $hook_override_tos_display = Hook::exec('overrideTOSDisplay');
+
+        $this->context->smarty->assign(array(
+            'total_price' => (float)$orderTotal,
+            'taxes_enabled' => (int)Configuration::get('PS_TAX'),
+            'cms_id' => (int)Configuration::get('PS_CONDITIONS_CMS_ID'),
+            'conditions' => (int)Configuration::get('PS_CONDITIONS'),
+            'checkedTOS' => (int)$this->context->cart->checkedTOS,
+            'override_tos_display' => $hook_override_tos_display
+        ));
+
+
+        parent::_assignPayment();
+    }
+
+    public function setMedia()
+    {
+        parent::setMedia();
+        if ($this->step == 2) {
+            $this->addJS(_THEME_JS_DIR_.'order-carrier.js');
+        }
+    }
 }

--- a/controllers/front/OrderOpcController.php
+++ b/controllers/front/OrderOpcController.php
@@ -1,5 +1,1165 @@
 <?php
+/*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
 
 class OrderOpcControllerCore extends ParentOrderController
 {
+    public $php_self = 'order-opc';
+    public $isLogged;
+
+    /**
+     * @var CheckoutProcess
+     */
+    protected $checkoutProcess;
+
+    protected $ajax_refresh = false;
+
+    /**
+     * Initialize order opc controller
+     * @see FrontController::init()
+     */
+    public function init()
+    {
+        parent::init();
+
+        if ($this->nbProducts) {
+            $this->context->smarty->assign('virtual_cart', $this->context->cart->isVirtualCart());
+        }
+
+        $this->context->smarty->assign('is_multi_address_delivery', $this->context->cart->isMultiAddressDelivery() || ((int)Tools::getValue('multi-shipping') == 1));
+        $this->context->smarty->assign('open_multishipping_fancybox', (int)Tools::getValue('multi-shipping') == 1);
+
+        if ($this->context->cart->nbProducts()) {
+            if (Tools::isSubmit('ajax')) {
+                if (Tools::isSubmit('method')) {
+                    switch (Tools::getValue('method')) {
+                        case 'updateMessage':
+                            if (Tools::isSubmit('message')) {
+                                $txt_message = urldecode(Tools::getValue('message'));
+                                $this->_updateMessage($txt_message);
+                                if (count($this->errors)) {
+                                    $this->ajaxDie('{"hasError" : true, "errors" : ["'.implode('\',\'', $this->errors).'"]}');
+                                }
+                                $this->ajaxDie(true);
+                            }
+                            break;
+
+                        case 'updateCarrierAndGetPayments':
+                            if ((Tools::isSubmit('delivery_option') || Tools::isSubmit('id_carrier')) && Tools::isSubmit('recyclable') && Tools::isSubmit('gift') && Tools::isSubmit('gift_message')) {
+                                $this->_assignWrappingAndTOS();
+                                if ($this->_processCarrier()) {
+                                    $carriers = $this->context->cart->simulateCarriersOutput();
+                                    $return = array_merge(array(
+                                        'HOOK_TOP_PAYMENT' => Hook::exec('displayPaymentTop'),
+                                        'HOOK_PAYMENT' => $this->_getPaymentMethods(),
+                                        'carrier_data' => $this->_getCarrierList(),
+                                        'HOOK_BEFORECARRIER' => Hook::exec('displayBeforeCarrier', array('carriers' => $carriers))
+                                        ),
+                                        $this->getFormatedSummaryDetail()
+                                    );
+                                    Cart::addExtraCarriers($return);
+                                    $this->ajaxDie(json_encode($return));
+                                } else {
+                                    $this->errors[] = Tools::displayError('An error occurred while updating the cart.');
+                                }
+                                if (count($this->errors)) {
+                                    $this->ajaxDie('{"hasError" : true, "errors" : ["'.implode('\',\'', $this->errors).'"]}');
+                                }
+                                exit;
+                            }
+                            break;
+
+                        case 'updateTOSStatusAndGetPayments':
+                            if (Tools::isSubmit('checked')) {
+                                $this->context->cookie->checkedTOS = (int)Tools::getValue('checked');
+                                $this->ajaxDie(json_encode(array(
+                                    'HOOK_TOP_PAYMENT' => Hook::exec('displayPaymentTop'),
+                                    'HOOK_PAYMENT' => $this->_getPaymentMethods()
+                                )));
+                            }
+                            break;
+
+                        case 'getCarrierList':
+                            $this->ajaxDie(json_encode($this->_getCarrierList()));
+                            break;
+
+                        case 'editCustomer':
+                            if (!$this->isLogged || !$this->context->customer->is_guest) {
+                                exit;
+                            }
+
+                            if (Validate::isEmail($email = Tools::getValue('email')) && !empty($email)) {
+                                if (Customer::customerExists($email)) {
+                                    $this->errors[] = Tools::displayError('An account using this email address has already been registered.', false);
+                                }
+                            }
+
+                            if (Tools::getValue('years')) {
+                                $this->context->customer->birthday = (int)Tools::getValue('years').'-'.(int)Tools::getValue('months').'-'.(int)Tools::getValue('days');
+                            }
+
+                            $phone = Tools::getValue('phone');
+                            if (Configuration::get('PS_ONE_PHONE_AT_LEAST') && !$phone) {
+                                $this->errors[] = Tools::displayError('Phone number is a required field.', false);
+                            }
+
+                            $this->context->customer->phone = $phone;
+                            $_POST['lastname'] = $_POST['customer_lastname'];
+                            $_POST['firstname'] = $_POST['customer_firstname'];
+                            $this->errors = array_merge($this->errors, $this->context->customer->validateController());
+                            $this->context->customer->newsletter = (int)Tools::isSubmit('newsletter');
+                            $this->context->customer->optin = (int)Tools::isSubmit('optin');
+                            $this->context->customer->is_guest = (Tools::isSubmit('is_new_customer') ? !Tools::getValue('is_new_customer', 1) : 0);
+
+                            if ($idAddressDelivery = Tools::getValue('opc_id_address_delivery')) {
+                                $objAddress = new Address($idAddressDelivery);
+                                if (Validate::isLoadedObject($objAddress)) {
+
+                                    if (!count($this->errors)) {
+                                        $objAddress->phone_mobile = $phone;
+                                        $objAddress->firstname = $this->context->customer->firstname;
+                                        $objAddress->lastname = $this->context->customer->lastname;
+                                        if (!$objAddress->save()) {
+                                            $this->errors[] = Tools::displayError('Something went wrong while saving phone number. Please try again.', false);
+                                        }
+                                    }
+                                }
+                            }
+
+                            $return = array(
+                                'hasError' => !empty($this->errors),
+                                'errors' => $this->errors,
+                                'id_customer' => (int)$this->context->customer->id,
+                                'token' => Tools::getToken(false)
+                            );
+                            if (!count($this->errors)) {
+                                $return['isSaved'] = (bool)$this->context->customer->update();
+
+                            } else {
+                                $return['isSaved'] = false;
+                            }
+                            $this->ajaxDie(json_encode($return));
+                            break;
+
+                        case 'transformGuestAccount':
+                            $passwd = Tools::getValue('passwd');
+
+                            if (!$passwd) {
+                                $this->errors[] = Tools::displayError('Please enter a password.');
+                            }
+
+                            if ($passwd && !Validate::isPasswd($passwd)) {
+                                $this->errors[] = Tools::displayError('Please enter a valid password.');
+                            }
+
+                            if (!count($this->errors)) {
+                                $customer = new Customer($this->context->customer->id);
+                                if (!$customer->isGuest()) {
+                                    $this->errors[] = Tools::displayError('This account is already registered as a customer.');
+                                } else if ($customer->transformToCustomer($this->context->language->id, $passwd)) {
+                                    $this->context->updateCustomer($customer);
+                                } else {
+                                    $this->errors[] = Tools::displayError('An error occurred while transforming your account into a registered customer.');
+                                }
+                            }
+
+                            $return = array(
+                                'hasError' => !empty($this->errors),
+                                'errors' => $this->errors,
+                            );
+
+                            $this->ajaxDie(json_encode($return));
+                            break;
+
+                        case 'getAddressBlockAndCarriersAndPayments':
+                            if ($this->context->customer->isLogged() || $this->context->customer->isGuest()) {
+                                // check if customer have addresses
+                                if (!Customer::getAddressesTotalById($this->context->customer->id)) {
+                                    $this->ajaxDie(json_encode(array('no_address' => 1)));
+                                }
+                                if (file_exists(_PS_MODULE_DIR_.'blockuserinfo/blockuserinfo.php')) {
+                                    include_once(_PS_MODULE_DIR_.'blockuserinfo/blockuserinfo.php');
+                                    $block_user_info = new BlockUserInfo();
+                                }
+                                $this->context->smarty->assign('isVirtualCart', $this->context->cart->isVirtualCart());
+                                $this->_processAddressFormat();
+                                $this->_assignAddress();
+
+                                if (!($formated_address_fields_values_list = $this->context->smarty->getTemplateVars('formatedAddressFieldsValuesList'))) {
+                                    $formated_address_fields_values_list = array();
+                                }
+
+                                // Wrapping fees
+                                $wrapping_fees = $this->context->cart->getGiftWrappingPrice(false);
+                                $wrapping_fees_tax_inc = $this->context->cart->getGiftWrappingPrice();
+                                $is_adv_api = Tools::getValue('isAdvApi');
+
+                                if ($is_adv_api) {
+                                    $tpl = 'order-address-advanced.tpl';
+                                    $this->context->smarty->assign(
+                                        array('products' => $this->context->cart->getProducts())
+                                    );
+                                } else {
+                                    $tpl = 'order-address.tpl';
+                                }
+
+                                $return = array_merge(array(
+                                    'order_opc_adress' => $this->context->smarty->fetch(_PS_THEME_DIR_.$tpl),
+                                    'block_user_info' => '',
+                                    // 'block_user_info_nav' => (isset($block_user_info) ? $block_user_info->hookDisplayTop(array()) : ''), //changed to below line
+                                    'block_user_info_nav' => (isset($block_user_info) ? $block_user_info->displayUserInfo(array()) : ''),
+                                    'formatedAddressFieldsValuesList' => $formated_address_fields_values_list,
+                                    'carrier_data' => ($is_adv_api ? '' : $this->_getCarrierList()),
+                                    'HOOK_TOP_PAYMENT' => ($is_adv_api ? '' : Hook::exec('displayPaymentTop')),
+                                    'HOOK_PAYMENT' => ($is_adv_api ? '' : $this->_getPaymentMethods()),
+                                    'no_address' => 0,
+                                    'gift_price' => Tools::displayPrice(Tools::convertPrice(
+                                        Product::getTaxCalculationMethod() == 1 ? $wrapping_fees : $wrapping_fees_tax_inc,
+                                        new Currency((int)$this->context->cookie->id_currency)))
+                                    ),
+                                    $this->getFormatedSummaryDetail()
+                                );
+                                $this->ajaxDie(json_encode($return));
+                            }
+                            die(Tools::displayError());
+                            break;
+
+                        case 'makeFreeOrder':
+                            /* Bypass payment step if total is 0 */
+                            if (($id_order = $this->_checkFreeOrder()) && $id_order) {
+                                $order = new Order((int)$id_order);
+                                $email = $this->context->customer->email;
+                                $orderConfirmationUrl = $this->context->link->getPageLink('order-confirmation').'?id_cart='.$order->id_cart.'&id_module=-1'.'&id_order='.$id_order.'&key='.$order->secure_key;
+                                if ($this->context->customer->is_guest) {
+                                    $this->context->customer->logout();
+                                } // If guest we clear the cookie for security reason
+
+                                $return = array(
+                                    'success' => true,
+                                    'reference' => $order->reference,
+                                    'email' => $email,
+                                    'order_confirmation_url' => $orderConfirmationUrl,
+                                );
+
+                                $this->ajaxDie(json_encode($return));
+                            }
+                            exit;
+                            break;
+
+                        case 'updateAddressesSelected':
+                            if ($this->context->customer->isLogged(true)) {
+                                $address_delivery = new Address((int)Tools::getValue('id_address_delivery'));
+                                $this->context->smarty->assign('isVirtualCart', $this->context->cart->isVirtualCart());
+                                $address_invoice = ((int)Tools::getValue('id_address_delivery') == (int)Tools::getValue('id_address_invoice') ? $address_delivery : new Address((int)Tools::getValue('id_address_invoice')));
+                                if ($address_delivery->id_customer != $this->context->customer->id || $address_invoice->id_customer != $this->context->customer->id) {
+                                    $this->errors[] = Tools::displayError('This address is not yours.');
+                                } elseif (!Address::isCountryActiveById((int)Tools::getValue('id_address_delivery'))) {
+                                    $this->errors[] = Tools::displayError('This address is not in a valid area.');
+                                } elseif (!Validate::isLoadedObject($address_delivery) || !Validate::isLoadedObject($address_invoice) || $address_invoice->deleted || $address_delivery->deleted) {
+                                    $this->errors[] = Tools::displayError('This address is invalid.');
+                                } else {
+                                    $this->context->cart->id_address_delivery = (int)Tools::getValue('id_address_delivery');
+                                    $this->context->cart->id_address_invoice = Tools::isSubmit('same') ? $this->context->cart->id_address_delivery : (int)Tools::getValue('id_address_invoice');
+                                    if (!$this->context->cart->update()) {
+                                        $this->errors[] = Tools::displayError('An error occurred while updating your cart.');
+                                    }
+
+                                    $infos = Address::getCountryAndState((int)$this->context->cart->id_address_delivery);
+                                    if (isset($infos['id_country']) && $infos['id_country']) {
+                                        $country = new Country((int)$infos['id_country']);
+                                        $this->context->country = $country;
+                                    }
+
+                                    // Address has changed, so we check if the cart rules still apply
+                                    $cart_rules = $this->context->cart->getCartRules();
+                                    CartRule::autoRemoveFromCart($this->context);
+                                    CartRule::autoAddToCart($this->context);
+                                    if ((int)Tools::getValue('allow_refresh')) {
+                                        // If the cart rules has changed, we need to refresh the whole cart
+                                        $cart_rules2 = $this->context->cart->getCartRules();
+                                        if (count($cart_rules2) != count($cart_rules)) {
+                                            $this->ajax_refresh = true;
+                                        } else {
+                                            $rule_list = array();
+                                            foreach ($cart_rules2 as $rule) {
+                                                $rule_list[] = $rule['id_cart_rule'];
+                                            }
+                                            foreach ($cart_rules as $rule) {
+                                                if (!in_array($rule['id_cart_rule'], $rule_list)) {
+                                                    $this->ajax_refresh = true;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    if (!$this->context->cart->isMultiAddressDelivery()) {
+                                        $this->context->cart->setNoMultishipping();
+                                    } // As the cart is no multishipping, set each delivery address lines with the main delivery address
+
+                                    if (!count($this->errors)) {
+                                        $result = $this->_getCarrierList();
+                                        // Wrapping fees
+                                        $wrapping_fees = $this->context->cart->getGiftWrappingPrice(false);
+                                        $wrapping_fees_tax_inc = $this->context->cart->getGiftWrappingPrice();
+                                        $result = array_merge($result, array(
+                                            'HOOK_TOP_PAYMENT' => Hook::exec('displayPaymentTop'),
+                                            'HOOK_PAYMENT' => $this->_getPaymentMethods(),
+                                            'gift_price' => Tools::displayPrice(Tools::convertPrice(Product::getTaxCalculationMethod() == 1 ? $wrapping_fees : $wrapping_fees_tax_inc, new Currency((int)$this->context->cookie->id_currency))),
+                                            'carrier_data' => $this->_getCarrierList(),
+                                            'refresh' => (bool)$this->ajax_refresh),
+                                            $this->getFormatedSummaryDetail()
+                                        );
+                                        $this->ajaxDie(json_encode($result));
+                                    }
+                                }
+                                if (count($this->errors)) {
+                                    $this->ajaxDie(json_encode(array(
+                                        'hasError' => true,
+                                        'errors' => $this->errors
+                                    )));
+                                }
+                            }
+                            die(Tools::displayError());
+                            break;
+
+                        case 'multishipping':
+                            $this->_assignSummaryInformations();
+                            $this->context->smarty->assign('product_list', $this->context->cart->getProducts());
+
+                            if ($this->context->customer->id) {
+                                $this->context->smarty->assign('address_list', $this->context->customer->getAddresses($this->context->language->id));
+                            } else {
+                                $this->context->smarty->assign('address_list', array());
+                            }
+                            $this->setTemplate(_PS_THEME_DIR_.'order-address-multishipping-products.tpl');
+                            $this->display();
+                            $this->ajaxDie();
+                            break;
+
+                        case 'cartReload':
+                            $this->_assignSummaryInformations();
+                            if ($this->context->customer->id) {
+                                $this->context->smarty->assign('address_list', $this->context->customer->getAddresses($this->context->language->id));
+                            } else {
+                                $this->context->smarty->assign('address_list', array());
+                            }
+                            $this->context->smarty->assign('opc', true);
+                            $this->setTemplate(_PS_THEME_DIR_.'shopping-cart.tpl');
+                            $this->display();
+                            $this->ajaxDie();
+                            break;
+
+                        case 'noMultiAddressDelivery':
+                            $this->context->cart->setNoMultishipping();
+                            $this->ajaxDie();
+                            break;
+                        case 'getRoomTypeBookingDemands':
+                            $this->ajaxDie($this->getRoomTypeBookingServices());
+                            exit;
+                            break;
+                        case 'changeRoomDemands':
+                            $this->ajaxDie($this->changeRoomDemands());
+                            exit;
+                            break;
+                        case 'getCustomerGuestDetail':
+                            $this->ajaxDie($this->getCustomerGuestDetail());
+                            exit;
+                            break;
+                        case 'getOpcData':
+                            $this->ajaxDie($this->getOpcData());
+                        default:
+                            throw new PrestaShopException('Unknown method "'.Tools::getValue('method').'"');
+                    }
+                } else {
+                    throw new PrestaShopException('Method is not defined');
+                }
+            }
+        } elseif (Tools::isSubmit('ajax')) {
+            $this->errors[] = Tools::displayError('There is no product in your cart.');
+            $this->ajaxDie('{"hasError" : true, "errors" : ["'.implode('\',\'', $this->errors).'"]}');
+        }
+    }
+
+    public function setMedia()
+    {
+        parent::setMedia();
+
+        if (!$this->useMobileTheme()) {
+            // Adding CSS style sheet
+            $this->addCSS(_THEME_CSS_DIR_.'order-opc.css');
+            // Adding JS files
+            $this->addJS(_THEME_JS_DIR_.'order-opc.js');
+            $this->addJqueryPlugin('scrollTo');
+        } else {
+            $this->addJS(_THEME_MOBILE_JS_DIR_.'opc.js');
+        }
+
+        $this->addJS(array(
+            _THEME_JS_DIR_.'tools/statesManagement.js',
+            _THEME_JS_DIR_.'order-carrier.js',
+            _PS_JS_DIR_.'validate.js'
+        ));
+    }
+
+    /**
+     * Assign template vars related to page content
+     * @see FrontController::initContent()
+     */
+    public function initContent()
+    {
+        $this->_assignCheckoutValidationVars();
+        parent::initContent();
+
+        if ($this->isInquiryMode()) {
+            return;
+        }
+
+        if (Tools::getValue('submitGuestDetails')) {
+            $this->submitCustomerGuestDetail();
+        }
+
+        /* id_carrier is not defined in database before choosing a carrier, set it to a default one to match a potential cart _rule */
+        if (empty($this->context->cart->id_carrier)) {
+            $checked = $this->context->cart->simulateCarrierSelectedOutput();
+            $checked = ((int)Cart::desintifier($checked));
+            $this->context->cart->id_carrier = $checked;
+            $this->context->cart->update();
+            CartRule::autoRemoveFromCart($this->context);
+            CartRule::autoAddToCart($this->context);
+        }
+
+        // SHOPPING CART
+        $this->_assignSummaryInformations();
+        // WRAPPING AND TOS
+        $this->_assignWrappingAndTOS();
+
+        if (Configuration::get('PS_RESTRICT_DELIVERED_COUNTRIES')) {
+            $countries = Carrier::getDeliveredCountries($this->context->language->id, true, true);
+        } else {
+            $countries = Country::getCountries($this->context->language->id, true);
+        }
+
+        // If a rule offer free-shipping, force hidding shipping prices
+        $free_shipping = false;
+        foreach ($this->context->cart->getCartRules() as $rule) {
+            if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
+                $free_shipping = true;
+                break;
+            }
+        }
+        if ($this->context->cart->id_address_delivery) {
+            // send address formatted layout data
+            if (Validate::isLoadedObject($address = new Address($this->context->cart->id_address_delivery))) {
+                $addressLayout = AddressFormat::getFormattedLayoutData($address);
+                $orderedAddressFields = AddressFormat::getOrderedAddressFields($address->id_country, false, true);
+                $this->context->smarty->assign(
+                    array(
+                        'orderedAddressFields' => $orderedAddressFields,
+                        'addressLayout' => $addressLayout
+                    )
+                );
+            }
+        }
+
+        // if any error is there in the checkout process the reset the steps of checkout
+        if (count($this->errors)) {
+            CheckoutProcess::refreshCheckoutProcess();
+        }
+
+        // assign checkout process steps
+        $this->setCheckoutProcess();
+
+        // if there is cookie variable in the url the redirect
+        if (Tools::getValue('proceed_to_customer_dtl') || Tools::getValue('proceed_to_payment')) {
+            Tools::redirect($this->context->link->getPageLink('order-opc', null, $this->context->language->id));
+        }
+
+        $this->context->smarty->assign('checkout_process_steps', $this->checkoutProcess->getSteps());
+
+        // set room type demands
+        // $objGlobalDemand = new HotelRoomTypeGlobalDemand();
+        // $allDemands = $objGlobalDemand->getAllDemands();
+        // $objCurrency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
+        $this->_assignCheckoutVars();
+        $this->context->smarty->assign(
+            array(
+                // 'allDemands' => $allDemands,
+                // 'defaultcurrencySign' => $objCurrency->sign,
+                'PS_REGISTRATION_PROCESS_TYPE' => Configuration::get('PS_REGISTRATION_PROCESS_TYPE'),
+                'free_shipping' => $free_shipping,
+                'isGuest' => isset($this->context->cookie->is_guest) ? $this->context->cookie->is_guest : 0,
+                'countries' => $countries,
+                'sl_country' => (int)Tools::getCountry(),
+                'PS_GUEST_CHECKOUT_ENABLED' => Configuration::get('PS_GUEST_CHECKOUT_ENABLED'),
+                'errorCarrier' => Tools::displayError('You must choose a carrier.', false),
+                'errorTOS' => Tools::displayError('You must accept the Terms of Service.', false),
+                'isPaymentStep' => isset($_GET['isPaymentStep']) && $_GET['isPaymentStep'],
+                'genders' => Gender::getGenders(),
+                'one_phone_at_least' => (int)Configuration::get('PS_ONE_PHONE_AT_LEAST'),
+                'HOOK_CREATE_ACCOUNT_FORM' => Hook::exec('displayCustomerAccountForm'),
+                'HOOK_CREATE_ACCOUNT_TOP' => Hook::exec('displayCustomerAccountFormTop')
+            )
+        );
+        $years = Tools::dateYears();
+        $months = Tools::dateMonths();
+        $days = Tools::dateDays();
+        $this->context->smarty->assign(
+            array(
+                'years' => $years,
+                'months' => $months,
+                'days' => $days,
+            )
+        );
+
+        /* Load guest informations */
+        if ($this->isLogged) {
+            if ($this->context->cookie->is_guest) {
+                $this->context->smarty->assign('guestInformations', $this->_getGuestInformations());
+            } else {
+                $this->context->smarty->assign('guestInformations', (array)$this->context->customer);
+            }
+        }
+        // ADDRESS
+        if ($this->isLogged) {
+            $this->_assignAddress();
+        }
+        // CARRIER
+        $this->_assignCarrier();
+        // PAYMENT
+        $this->_assignPayment();
+        // GUEST BOOKING
+        if ($this->isLogged) {
+            if ($idCustomerGuestDetail = CustomerGuestDetail::getCustomerGuestIdByIdCart($this->context->cart->id)) {
+                $this->context->smarty->assign(
+                    'customer_guest_detail', CustomerGuestDetail::getCustomerGuestDetailById($idCustomerGuestDetail)
+                );
+            }
+            $this->context->smarty->assign('id_customer_guest_detail', $idCustomerGuestDetail);
+        }
+        Tools::safePostVars();
+
+        $newsletter = Module::isInstalled('blocknewsletter') && Module::getInstanceByName('blocknewsletter')->active && Configuration::get('PS_CUSTOMER_NWSL');
+        $this->context->smarty->assign('birthday', (bool) Configuration::get('PS_CUSTOMER_BIRTHDATE'));
+        $this->context->smarty->assign('newsletter', $newsletter);
+        $this->context->smarty->assign('optin', (bool)Configuration::get('PS_CUSTOMER_OPTIN'));
+        $this->context->smarty->assign('field_required', $this->context->customer->validateFieldsRequiredDatabase());
+
+        $this->_processAddressFormat();
+
+        $link = new Link();
+
+        if (Tools::getValue('deleteFromOrderLine')) {
+            $id_product = Tools::getValue('id_product');
+            $date_from = Tools::getValue('date_from');
+            $date_to = Tools::getValue('date_to');
+            $objCartBookingData = new HotelCartBookingData();
+            if ($objCartBookingData->deleteRoomDataFromOrderLine(
+                $this->context->cart->id,
+                $this->context->cart->id_guest,
+                $id_product,
+                $date_from,
+                $date_to
+            )) {
+                Tools::redirect($link->getPageLink('order-opc', null, $this->context->language->id));
+            }
+        }
+
+        if ((bool)Configuration::get('PS_ADVANCED_PAYMENT_API')) {
+            $this->addJS(_THEME_JS_DIR_ . 'advanced-payment-api.js');
+            $this->setTemplate(_PS_THEME_DIR_ . 'order-opc-advanced.tpl');
+        } else {
+            $this->_assignShoppingCart();
+            $this->setTemplate(_PS_THEME_DIR_.'order-opc.tpl');
+        }
+    }
+
+    // sets checkout process steps as per current values
+    private function setCheckoutProcess()
+    {
+        $this->checkoutProcess = new CheckoutProcess();
+        // add the steps you want to add in checkout process
+        $this->checkoutProcess
+            ->addStep(new CheckoutCartSummaryStep())
+            ->addStep(new CheckoutCustomerDetailsStep())
+            ->addStep(new CheckoutPaymentStep());
+
+        $this->checkoutProcess->handleRequest();
+
+        // for making steps synced
+        $this->checkoutProcess
+            ->setNextStepReachable()
+            ->markCurrentStep()
+            ->invalidateAllStepsAfterCurrent();
+    }
+
+    protected function _getGuestInformations()
+    {
+        $customer = $this->context->customer;
+        $address_delivery = new Address($this->context->cart->id_address_delivery);
+
+        $id_address_invoice = $this->context->cart->id_address_invoice != $this->context->cart->id_address_delivery ? (int)$this->context->cart->id_address_invoice : 0;
+        $address_invoice = new Address($id_address_invoice);
+
+        if ($customer->birthday) {
+            $birthday = explode('-', $customer->birthday);
+        } else {
+            $birthday = array('0', '0', '0');
+        }
+
+        return array(
+            'id_customer' => (int)$customer->id,
+            'email' => Tools::htmlentitiesUTF8($customer->email),
+            'customer_lastname' => Tools::htmlentitiesUTF8($customer->lastname),
+            'customer_firstname' => Tools::htmlentitiesUTF8($customer->firstname),
+            'newsletter' => (int)$customer->newsletter,
+            'optin' => (int)$customer->optin,
+            'id_address_delivery' => (int)$this->context->cart->id_address_delivery,
+            'company' => Tools::htmlentitiesUTF8($address_delivery->company),
+            'lastname' => Tools::htmlentitiesUTF8($address_delivery->lastname),
+            'firstname' => Tools::htmlentitiesUTF8($address_delivery->firstname),
+            'dni' => Tools::htmlentitiesUTF8($address_delivery->dni),
+            'address1' => Tools::htmlentitiesUTF8($address_delivery->address1),
+            'postcode' => Tools::htmlentitiesUTF8($address_delivery->postcode),
+            'city' => Tools::htmlentitiesUTF8($address_delivery->city),
+            'phone' => Tools::htmlentitiesUTF8($address_delivery->phone),
+            'phone_mobile' => Tools::htmlentitiesUTF8($address_delivery->phone_mobile),
+            'id_country' => (int)$address_delivery->id_country,
+            'id_state' => (int)$address_delivery->id_state,
+            'id_gender' => (int)$customer->id_gender,
+            'phone' => $customer->phone,
+            'sl_year' => $birthday[0],
+            'sl_month' => $birthday[1],
+            'sl_day' => $birthday[2],
+            'company_invoice' => Tools::htmlentitiesUTF8($address_invoice->company),
+            'lastname_invoice' => Tools::htmlentitiesUTF8($address_invoice->lastname),
+            'firstname_invoice' => Tools::htmlentitiesUTF8($address_invoice->firstname),
+            'dni_invoice' => Tools::htmlentitiesUTF8($address_invoice->dni),
+            'address1_invoice' => Tools::htmlentitiesUTF8($address_invoice->address1),
+            'address2_invoice' => Tools::htmlentitiesUTF8($address_invoice->address2),
+            'postcode_invoice' => Tools::htmlentitiesUTF8($address_invoice->postcode),
+            'city_invoice' => Tools::htmlentitiesUTF8($address_invoice->city),
+            'phone_invoice' => Tools::htmlentitiesUTF8($address_invoice->phone),
+            'phone_mobile_invoice' => Tools::htmlentitiesUTF8($address_invoice->phone_mobile),
+            'id_country_invoice' => (int)$address_invoice->id_country,
+            'id_state_invoice' => (int)$address_invoice->id_state,
+            'id_address_invoice' => $id_address_invoice,
+            'invoice_company' => Tools::htmlentitiesUTF8($address_invoice->company),
+            'invoice_lastname' => Tools::htmlentitiesUTF8($address_invoice->lastname),
+            'invoice_firstname' => Tools::htmlentitiesUTF8($address_invoice->firstname),
+            'invoice_vat_number' => Tools::htmlentitiesUTF8($address_invoice->vat_number),
+            'invoice_dni' => Tools::htmlentitiesUTF8($address_invoice->dni),
+            'invoice_address' => $this->context->cart->id_address_invoice !== $this->context->cart->id_address_delivery,
+            'invoice_address1' => Tools::htmlentitiesUTF8($address_invoice->address1),
+            'invoice_address2' => Tools::htmlentitiesUTF8($address_invoice->address2),
+            'invoice_postcode' => Tools::htmlentitiesUTF8($address_invoice->postcode),
+            'invoice_city' => Tools::htmlentitiesUTF8($address_invoice->city),
+            'invoice_phone' => Tools::htmlentitiesUTF8($address_invoice->phone),
+            'invoice_phone_mobile' => Tools::htmlentitiesUTF8($address_invoice->phone_mobile),
+            'invoice_id_country' => (int)$address_invoice->id_country,
+            'invoice_id_state' => (int)$address_invoice->id_state,
+        );
+    }
+
+    protected function _assignCarrier()
+    {
+        if (!$this->isLogged) {
+            $carriers = $this->context->cart->simulateCarriersOutput();
+            $old_message = Message::getMessageByCartId((int)$this->context->cart->id);
+            $this->context->smarty->assign(array(
+                'HOOK_EXTRACARRIER' => null,
+                'HOOK_EXTRACARRIER_ADDR' => null,
+                'oldMessage' => isset($old_message['message'])? $old_message['message'] : '',
+                'HOOK_BEFORECARRIER' => Hook::exec('displayBeforeCarrier', array(
+                    'carriers' => $carriers,
+                    'checked' => $this->context->cart->simulateCarrierSelectedOutput(),
+                    'delivery_option_list' => $this->context->cart->getDeliveryOptionList(),
+                    'delivery_option' => $this->context->cart->getDeliveryOption(null, true)
+                ))
+            ));
+        } else {
+            parent::_assignCarrier();
+        }
+    }
+
+    protected function _assignPayment()
+    {
+        if ((bool)Configuration::get('PS_ADVANCED_PAYMENT_API')) {
+            $this->context->smarty->assign(array(
+                'HOOK_TOP_PAYMENT' => ($this->isLogged ? Hook::exec('displayPaymentTop') : ''),
+                'HOOK_PAYMENT' => $this->_getPaymentMethods(),
+                'HOOK_ADVANCED_PAYMENT' => Hook::exec('advancedPaymentOptions', array(), null, true),
+                'link_conditions' => $this->link_conditions
+            ));
+        } else {
+            $this->context->smarty->assign(array(
+                'HOOK_TOP_PAYMENT' => ($this->isLogged ? Hook::exec('displayPaymentTop') : ''),
+                'HOOK_PAYMENT' => $this->_getPaymentMethods()
+            ));
+        }
+    }
+
+    protected function _getPaymentMethods()
+    {
+        if (!$this->isLogged) {
+            return '<p class="warning">'.Tools::displayError('Please sign in to see payment methods.').'</p>';
+        }
+        if ($this->context->cart->OrderExists()) {
+            return '<p class="warning">'.Tools::displayError('Error: This order has already been validated.').'</p>';
+        }
+        if (!$this->context->cart->id_customer || !Customer::customerIdExistsStatic($this->context->cart->id_customer) || Customer::isBanned($this->context->cart->id_customer)) {
+            return '<p class="warning">'.Tools::displayError('Error: No customer.').'</p>';
+        }
+        $address_delivery = new Address($this->context->cart->id_address_delivery);
+        $address_invoice = ($this->context->cart->id_address_delivery == $this->context->cart->id_address_invoice ? $address_delivery : new Address($this->context->cart->id_address_invoice));
+        if (count($this->context->cart->getDeliveryOptionList()) == 0 && !$this->context->cart->isVirtualCart()) {
+            if ($this->context->cart->isMultiAddressDelivery()) {
+                return '<p class="warning">'.Tools::displayError('Error: None of your chosen carriers deliver to some of the addresses you have selected.').'</p>';
+            } else {
+                return '<p class="warning">'.Tools::displayError('Error: None of your chosen carriers deliver to the address you have selected.').'</p>';
+            }
+        }
+        if (!$this->context->cart->getDeliveryOption(null, false) && !$this->context->cart->isVirtualCart()) {
+            return '<p class="warning">'.Tools::displayError('Error: Please choose a carrier.').'</p>';
+        }
+        if (!$this->context->cart->id_currency) {
+            return '<p class="warning">'.Tools::displayError('Error: No currency has been selected.').'</p>';
+        }
+        if (!$this->context->cookie->checkedTOS && Configuration::get('PS_CONDITIONS')) {
+            return '<p class="warning">'.Tools::displayError('Please accept the Terms of Service.').'</p>';
+        }
+
+        /* If some products have disappear */
+        if (is_array($product = $this->context->cart->checkQuantities(true))) {
+            return '<p class="warning">'.sprintf(Tools::displayError('An item (%s) in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.'), $product['name']).'</p>';
+        }
+
+        if ((int)$id_product = $this->context->cart->checkProductsAccess()) {
+            return '<p class="warning">'.sprintf(Tools::displayError('An item in your cart is no longer available (%s). You cannot proceed with your order.'), Product::getProductName((int)$id_product)).'</p>';
+        }
+
+        /* Check minimal amount */
+        $currency = Currency::getCurrency((int)$this->context->cart->id_currency);
+
+        $minimal_purchase = Tools::convertPrice((float)Configuration::get('PS_PURCHASE_MINIMUM'), $currency);
+        if ($this->context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS) < $minimal_purchase) {
+            return '<p class="warning">'.sprintf(
+                Tools::displayError('A minimum purchase total of %1s (tax excl.) is required to validate your order, current purchase total is %2s (tax excl.).'),
+                Tools::displayPrice($minimal_purchase, $currency), Tools::displayPrice($this->context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS), $currency)
+            ).'</p>';
+        }
+
+
+        // check if customer has chosen advance payment option for this cart
+        if ($this->context->cart->is_advance_payment) {
+            $orderTotal = $this->context->cart->getOrderTotal(true, CART::ADVANCE_PAYMENT);
+        } else {
+            $orderTotal = $this->context->cart->getOrderTotal();
+        }
+
+        /* Bypass payment step if total is 0 */
+        if ($orderTotal <= 0) {
+            return '<p class="center"><button class="button btn btn-default button-medium" name="confirmOrder" id="confirmOrder" onclick="confirmFreeOrder();" type="submit"> <span>'.Tools::displayError('I confirm my order.').'</span></button></p>';
+        }
+
+        $return = Hook::exec('displayPayment');
+        if (!$return) {
+            return '<p class="warning">'.Tools::displayError('No payment method is available for use at this time. ').'</p>';
+        }
+        return $return;
+    }
+
+    protected function _getCarrierList()
+    {
+        $address_delivery = new Address($this->context->cart->id_address_delivery);
+
+        $cms = new CMS(Configuration::get('PS_CONDITIONS_CMS_ID'), $this->context->language->id);
+        $link_conditions = $this->context->link->getCMSLink($cms, $cms->link_rewrite, Configuration::get('PS_SSL_ENABLED'));
+        if (!strpos($link_conditions, '?')) {
+            $link_conditions .= '?content_only=1';
+        } else {
+            $link_conditions .= '&content_only=1';
+        }
+
+        $carriers = $this->context->cart->simulateCarriersOutput();
+        $delivery_option = $this->context->cart->getDeliveryOption(null, false, false);
+
+        $wrapping_fees = $this->context->cart->getGiftWrappingPrice(false);
+        $wrapping_fees_tax_inc = $this->context->cart->getGiftWrappingPrice();
+        $old_message = Message::getMessageByCartId((int)$this->context->cart->id);
+
+        $free_shipping = false;
+        foreach ($this->context->cart->getCartRules() as $rule) {
+            if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
+                $free_shipping = true;
+                break;
+            }
+        }
+
+        $this->context->smarty->assign('isVirtualCart', $this->context->cart->isVirtualCart());
+
+        $vars = array(
+            'advanced_payment_api' => (bool)Configuration::get('PS_ADVANCED_PAYMENT_API'),
+            'free_shipping' => $free_shipping,
+            'checkedTOS' => (int)$this->context->cookie->checkedTOS,
+            'recyclablePackAllowed' => (int)Configuration::get('PS_RECYCLABLE_PACK'),
+            'giftAllowed' => (int)Configuration::get('PS_GIFT_WRAPPING'),
+            'cms_id' => (int)Configuration::get('PS_CONDITIONS_CMS_ID'),
+            'conditions' => (int)Configuration::get('PS_CONDITIONS'),
+            'link_conditions' => $link_conditions,
+            'recyclable' => (int)$this->context->cart->recyclable,
+            'gift_wrapping_price' => (float)$wrapping_fees,
+            'total_wrapping_cost' => Tools::convertPrice($wrapping_fees_tax_inc, $this->context->currency),
+            'total_wrapping_tax_exc_cost' => Tools::convertPrice($wrapping_fees, $this->context->currency),
+            'delivery_option_list' => $this->context->cart->getDeliveryOptionList(),
+            'carriers' => $carriers,
+            'checked' => $this->context->cart->simulateCarrierSelectedOutput(),
+            'delivery_option' => $delivery_option,
+            'address_collection' => $this->context->cart->getAddressCollection(),
+            'opc' => true,
+            'oldMessage' => isset($old_message['message'])? $old_message['message'] : '',
+            'HOOK_BEFORECARRIER' => Hook::exec('displayBeforeCarrier', array(
+                'carriers' => $carriers,
+                'delivery_option_list' => $this->context->cart->getDeliveryOptionList(),
+                'delivery_option' => $delivery_option
+            ))
+        );
+
+        Cart::addExtraCarriers($vars);
+
+        $this->context->smarty->assign($vars);
+
+        if (!Address::isCountryActiveById((int)$this->context->cart->id_address_delivery) && $this->context->cart->id_address_delivery != 0) {
+            $this->errors[] = Tools::displayError('This address is not in a valid area.');
+        } elseif ((!Validate::isLoadedObject($address_delivery) || $address_delivery->deleted) && $this->context->cart->id_address_delivery != 0) {
+            $this->errors[] = Tools::displayError('This address is invalid.');
+        } else {
+            $result = array(
+                'HOOK_BEFORECARRIER' => Hook::exec('displayBeforeCarrier', array(
+                    'carriers' => $carriers,
+                    'delivery_option_list' => $this->context->cart->getDeliveryOptionList(),
+                    'delivery_option' => $this->context->cart->getDeliveryOption(null, true)
+                )),
+                'carrier_block' => $this->context->smarty->fetch(_PS_THEME_DIR_.'order-carrier.tpl')
+            );
+
+            Cart::addExtraCarriers($result);
+            return $result;
+        }
+        if (count($this->errors)) {
+            return array(
+                'hasError' => true,
+                'errors' => $this->errors,
+                'carrier_block' => $this->context->smarty->fetch(_PS_THEME_DIR_.'order-carrier.tpl')
+            );
+        }
+    }
+
+    protected function _processAddressFormat()
+    {
+        $address_delivery = new Address((int)$this->context->cart->id_address_delivery);
+        $address_invoice = new Address((int)$this->context->cart->id_address_invoice);
+
+        $inv_adr_fields = AddressFormat::getOrderedAddressFields((int)$address_delivery->id_country, false, true);
+        $dlv_adr_fields = AddressFormat::getOrderedAddressFields((int)$address_invoice->id_country, false, true);
+        $require_form_fields_list = AddressFormat::getFieldsRequired();
+
+        // Add missing require fields for a new user susbscription form
+        foreach ($require_form_fields_list as $field_name) {
+            if (!in_array($field_name, $dlv_adr_fields)) {
+                $dlv_adr_fields[] = trim($field_name);
+            }
+        }
+
+        foreach ($require_form_fields_list as $field_name) {
+            if (!in_array($field_name, $inv_adr_fields)) {
+                $inv_adr_fields[] = trim($field_name);
+            }
+        }
+
+        $inv_all_fields = array();
+        $dlv_all_fields = array();
+
+        foreach (array('inv', 'dlv') as $adr_type) {
+            foreach (${$adr_type.'_adr_fields'} as $fields_line) {
+                foreach (explode(' ', $fields_line) as $field_item) {
+                    ${$adr_type.'_all_fields'}[] = trim($field_item);
+                }
+            }
+
+            ${$adr_type.'_adr_fields'} = array_unique(${$adr_type.'_adr_fields'});
+            ${$adr_type.'_all_fields'} = array_unique(${$adr_type.'_all_fields'});
+
+            $this->context->smarty->assign(
+                array(
+                    $adr_type.'_adr_fields' => ${$adr_type.'_adr_fields'},
+                    $adr_type.'_all_fields' => ${$adr_type.'_all_fields'},
+                    'required_fields' => $require_form_fields_list
+                )
+            );
+        }
+    }
+
+    protected function getFormatedSummaryDetail()
+    {
+        $result = array('summary' => $this->context->cart->getSummaryDetails(),
+                        'customizedDatas' => Product::getAllCustomizedDatas($this->context->cart->id, null, true));
+
+        foreach ($result['summary']['products'] as $key => &$product) {
+            $product['quantity_without_customization'] = $product['quantity'];
+            if ($result['customizedDatas']) {
+                if (isset($result['customizedDatas'][(int)$product['id_product']][(int)$product['id_product_attribute']])) {
+                    foreach ($result['customizedDatas'][(int)$product['id_product']][(int)$product['id_product_attribute']] as $addresses) {
+                        foreach ($addresses as $customization) {
+                            $product['quantity_without_customization'] -= (int)$customization['quantity'];
+                        }
+                    }
+                }
+            }
+        }
+
+        if ($result['customizedDatas']) {
+            Product::addCustomizationPrice($result['summary']['products'], $result['customizedDatas']);
+        }
+        return $result;
+    }
+
+    public function getRoomTypeBookingServices()
+    {
+        $response = array('reload' => true);
+        if ($idProduct = Tools::getValue('id_product')) {
+            if (($dateFrom = Tools::getValue('date_from'))
+                && ($dateTo = Tools::getValue('date_to'))
+            ) {
+                $objCartBookingData = new HotelCartBookingData();
+                if ($selectedRoomDemands = $objCartBookingData->getCartExtraDemands(
+                    $this->context->cart->id,
+                    $idProduct,
+                    0,
+                    $dateFrom,
+                    $dateTo
+                )) {
+                    // get room type additional demands
+                    $objRoomDemands = new HotelRoomTypeDemand();
+                    if ($roomTypeDemands = $objRoomDemands->getRoomTypeDemands($idProduct)) {
+                        foreach ($roomTypeDemands as &$demand) {
+                            // if demand has advance options then set demand price as first advance option price.
+                            if (isset($demand['adv_option']) && $demand['adv_option']) {
+                                $demand['price'] = current($demand['adv_option'])['price'];
+                            }
+                        }
+                        foreach ($selectedRoomDemands as &$selectedDemand) {
+                            if (isset($selectedDemand['extra_demands']) && $selectedDemand['extra_demands']) {
+                                $extraDmd = array();
+                                foreach ($selectedDemand['extra_demands'] as $sDemand) {
+                                    $selectedDemand['selected_global_demands'][] = $sDemand['id_global_demand'];
+                                    $extraDmd[$sDemand['id_global_demand'].'-'.$sDemand['id_option']] = $sDemand;
+                                }
+                                $selectedDemand['extra_demands'] = $extraDmd;
+                            }
+                        }
+                        $this->context->smarty->assign('roomTypeDemands', $roomTypeDemands);
+                        $this->context->smarty->assign('selectedRoomDemands', $selectedRoomDemands);
+
+                    }
+                }
+                $objServiceProductCartDetail = new ServiceProductCartDetail();
+                $objRoomTypeServiceProduct = new RoomTypeServiceProduct();
+                $roomTypeServiceProducts = $objRoomTypeServiceProduct->getServiceProductsData($idProduct, 1, 0, true, 1);
+                $cartBookings = $objCartBookingData->getHotelCartRoomsInfoByRoomType($this->context->cart->id, $idProduct,$dateFrom, $dateTo);
+                foreach($cartBookings as &$cartBookingData) {
+                    $cartBookingData['selected_service'] = $objServiceProductCartDetail->getServiceProductsInCart(
+                        $cartBookingData['id_cart'],
+                        [],
+                        null,
+                        $cartBookingData['id'],
+                        null,
+                        null,
+                        null,
+                        null,
+                        0,
+                        null,
+                        null,
+                        1
+                    );
+                }
+                $this->context->smarty->assign(array(
+                    'roomTypeServiceProducts' => $roomTypeServiceProducts,
+                    'cartRooms' => $cartBookings
+                ));
+            }
+        }
+        $response['extra_demands'] = $this->context->smarty->fetch(
+            _PS_THEME_DIR_.'_partials/cart_booking_demands.tpl'
+        );
+
+        return json_encode($response);
+    }
+
+    public function changeRoomDemands()
+    {
+        if ($idCartBooking = Tools::getValue('id_cart_booking')) {
+            if (Validate::isLoadedObject($objCartbookingCata = new HotelCartBookingData($idCartBooking))) {
+                $roomDemands = Tools::getValue('room_demands');
+                $roomDemands = json_decode($roomDemands, true);
+                $roomDemands = json_encode($roomDemands);
+                $objCartbookingCata->extra_demands = $roomDemands;
+                if ($objCartbookingCata->save()) {
+                    die('1');
+                }
+            }
+        }
+        die('0');
+    }
+
+    public function getCustomerGuestDetail()
+    {
+        $response = array('status' => false);
+        $firstname = trim(Tools::getValue('firstname'));
+        $lastname = trim(Tools::getValue('lastname'));
+        $email = trim(Tools::getValue('email'));
+        $objCustomerGuestDetail = new CustomerGuestDetail();
+        if ($guestDetails = $objCustomerGuestDetail->getCustomerGuestsByIdCustomer(
+            $this->context->cart->id_customer,
+            $firstname,
+            $lastname,
+            $email
+        )) {
+            $response['status'] = true;
+            $response['guest_details'] = $guestDetails;
+        }
+
+        return json_encode($response);
+    }
+
+
+    public function submitCustomerGuestDetail()
+    {
+        $customerGuestDetail = Tools::getValue('customer_guest_detail');
+        $this->context->cookie->__set('customer_details_proceeded', 0);
+        $this->context->cookie->checkedTOS = false;
+        if ($customerGuestDetail) {
+            $customerGuestDetailErrors = array();
+            $customerGuestDetailGender = Tools::getValue('customer_guest_detail_gender');
+            $customerGuestDetailFirstname = Tools::getValue('customer_guest_detail_firstname');
+            $customerGuestDetailLastname = Tools::getValue('customer_guest_detail_lastname');
+            $customerGuestDetailEmail = Tools::getValue('customer_guest_detail_email');
+            $customerGuestDetailPhone = Tools::getValue('customer_guest_detail_phone');
+            if ($idCustomerGuestDetail = CustomerGuestDetail::getCustomerGuestByEmail($customerGuestDetailEmail, $this->context->cart->id)) {
+                $objCustomerGuestDetail = new CustomerGuestDetail($idCustomerGuestDetail);
+            } else if ($idCustomerGuestDetail = CustomerGuestDetail::getCustomerGuestByEmail($customerGuestDetailEmail, $this->context->customer->id, null)) {
+                $objCustomerGuestDetail = new CustomerGuestDetail($idCustomerGuestDetail);
+            } else {
+                $objCustomerGuestDetail = new CustomerGuestDetail();
+            }
+
+            $className = 'CustomerGuestDetail';
+            $rules = call_user_func(array($className, 'getValidationRules'), $className);
+
+            if (!(trim($customerGuestDetailGender) || !Validate::isUnsignedInt($customerGuestDetailGender))) {
+                $customerGuestDetailErrors[] = Tools::displayError('Invalid gender');
+            }
+
+            if (!trim($customerGuestDetailFirstname)
+                || !Validate::isName($customerGuestDetailFirstname)
+                || !(!isset($rules['size']['firstname'])
+                   || (isset($rules['size']['firstname']) && (Tools::strlen(trim($customerGuestDetailFirstname)) <= $rules['size']['firstname']))
+                )
+            ) {
+                $customerGuestDetailErrors[] = Tools::displayError('Invalid first name');
+            }
+
+            if (!trim($customerGuestDetailLastname)
+                || !Validate::isName($customerGuestDetailLastname)
+                || !(!isset($rules['size']['lastname'])
+                  || (isset($rules['size']['lastname']) && (Tools::strlen(trim($customerGuestDetailLastname)) <= $rules['size']['lastname']))
+                )
+            ) {
+                $customerGuestDetailErrors[] = Tools::displayError('Invalid last name');
+            }
+
+            if (!trim($customerGuestDetailEmail)
+                || !Validate::isEmail($customerGuestDetailEmail)
+                || !(!isset($rules['size']['email'])
+                  || (isset($rules['size']['email']) && (Tools::strlen(trim($customerGuestDetailEmail)) <= $rules['size']['email']))
+                )
+            ) {
+                $customerGuestDetailErrors[] = Tools::displayError('Invalid email');
+            }
+
+            if (!trim($customerGuestDetailPhone)
+                || !Validate::isPhoneNumber($customerGuestDetailPhone)
+                || !(!isset($rules['size']['phone'])
+                  || (isset($rules['size']['phone']) && (Tools::strlen(trim($customerGuestDetailPhone)) <= $rules['size']['phone']))
+                )
+            ) {
+                $customerGuestDetailErrors[] = Tools::displayError('Invalid phone');
+            }
+
+            if (empty($customerGuestDetailErrors)) {
+                $objCustomerGuestDetail->id_gender = $customerGuestDetailGender;
+                $objCustomerGuestDetail->firstname = $customerGuestDetailFirstname;
+                $objCustomerGuestDetail->lastname = $customerGuestDetailLastname;
+                $objCustomerGuestDetail->email = $customerGuestDetailEmail;
+                $objCustomerGuestDetail->phone = $customerGuestDetailPhone;
+                $objCustomerGuestDetail->id_customer = $this->context->customer->id;
+                if ($objCustomerGuestDetail->save()) {
+                    if ($maxGuestAccountAllowed = Configuration::get('PS_CUSTOMER_GUEST_MAX_LIMIT')) {
+                        $objCustomerGuestDetail->deleteCustomerGuestByIdCustomer($this->context->cart->id_customer, $maxGuestAccountAllowed);
+                    }
+                    // To prevent duplications for the same cart.
+                    CustomerGuestDetail::deleteCustomerGuestInCart($this->context->cart->id);
+                    $objCustomerGuestDetail->saveCustomerGuestInCart($this->context->cart->id, $objCustomerGuestDetail->id);
+                    Tools::redirect($this->context->link->getPageLink('order-opc', null, $this->context->language->id, array('proceed_to_payment' => 1)));
+                }
+            }
+
+            $this->context->smarty->assign('customerGuestDetailErrors', $customerGuestDetailErrors);
+        } else {
+            CustomerGuestDetail::deleteCustomerGuestInCart($this->context->cart->id);
+            Tools::redirect($this->context->link->getPageLink('order-opc', null, $this->context->language->id, array('proceed_to_payment' => 1)));
+        }
+
+        $this->context->cart->save();
+    }
+
+    public function getOpcData()
+    {
+        $response = array('success' => false);
+        if ($this->context->cart->getProducts()) {
+            $this->_assignCheckoutValidationVars();
+            $this->_assignCheckoutVars();
+            $this->_assignShoppingCart();
+            $this->_assignSummaryInformations();
+            $response['success'] = true;
+            $response['shopping_cart'] = $this->context->smarty->fetch(_PS_THEME_DIR_.'shopping-cart.tpl');
+            $response['cart_total_block'] = $this->context->smarty->fetch(_PS_THEME_DIR_.'cart-total-block.tpl');
+        } else {
+            $response['reload'] = 1;
+        }
+
+        return json_encode($response);
+    }
 }

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -1,26 +1,736 @@
 <?php
+/*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
 
 class ParentOrderControllerCore extends FrontController
 {
+    public $ssl = true;
+    public $php_self = 'order';
+
+    public $nbProducts;
+    public $link_conditions;
+
+    /**
+     * Initialize parent order controller
+     * @see FrontController::init()
+     */
     public function init()
     {
+        $this->isLogged = $this->context->customer->id && Customer::customerIdExistsStatic((int)$this->context->cookie->id_customer);
+
         parent::init();
+
+        if ($this->isInquiryMode()) {
+            if (Tools::getValue('ajax')) {
+                $this->ajaxDie(json_encode(array(
+                    'hasError' => true,
+                    'errors' => array(Tools::displayError('Checkout is disabled while inquiry mode is active.')),
+                )));
+            }
+
+            Tools::redirect($this->getInquiryLink());
+        }
+
+        /* Disable some cache related bugs on the cart/order */
+        header('Cache-Control: no-cache, must-revalidate');
+        header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+
+        $this->nbProducts = $this->context->cart->nbProducts();
+
+        if (!$this->context->customer->isLogged(true) && $this->useMobileTheme() && Tools::getValue('step')) {
+            Tools::redirect($this->context->link->getPageLink('authentication', true, (int)$this->context->language->id));
+        }
+
+        // Redirect to the good order process
+        if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 0 && Dispatcher::getInstance()->getController() != 'order') {
+            Tools::redirect('index.php?controller=order');
+        }
+
+        if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 1 && Dispatcher::getInstance()->getController() != 'orderopc') {
+            if (Tools::getIsset('step') && Tools::getValue('step') == 3) {
+                Tools::redirect('index.php?controller=order-opc&isPaymentStep=true');
+            }
+            Tools::redirect('index.php?controller=order-opc');
+        }
+
+        if (Configuration::get('PS_CATALOG_MODE')) {
+            $this->errors[] = Tools::displayError('This store has not accepted your new order.');
+        }
+
+        if (Tools::isSubmit('submitReorder') && $id_order = (int)Tools::getValue('id_order')) {
+            $oldCart = new Cart(Order::getCartIdStatic($id_order, $this->context->customer->id));
+            $duplication = $oldCart->duplicate();
+            if (!$duplication || !Validate::isLoadedObject($duplication['cart'])) {
+                $this->errors[] = Tools::displayError('Sorry. We cannot renew your order.');
+            } elseif (!$duplication['success']) {
+                $this->errors[] = Tools::displayError('Some items are no longer available, and we are unable to renew your order.');
+            } else {
+                $this->context->cookie->id_cart = $duplication['cart']->id;
+                $context = $this->context;
+                $context->cart = $duplication['cart'];
+                CartRule::autoAddToCart($context);
+                $this->context->cookie->write();
+                if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 1) {
+                    Tools::redirect('index.php?controller=order-opc');
+                }
+                Tools::redirect('index.php?controller=order');
+            }
+        }
+
+        if ($this->nbProducts) {
+            if (CartRule::isFeatureActive()) {
+                if (Tools::isSubmit('submitAddDiscount')) {
+                    if (!($code = trim(Tools::getValue('discount_name')))) {
+                        $this->errors[] = Tools::displayError('You must enter a voucher code.');
+                    } elseif (!Validate::isCleanHtml($code)) {
+                        $this->errors[] = Tools::displayError('The voucher code is invalid.');
+                    } else {
+                        if (($cartRule = new CartRule(CartRule::getIdByCode($code))) && Validate::isLoadedObject($cartRule)) {
+                            if ($error = $cartRule->checkValidity($this->context, false, true)) {
+                                $this->errors[] = $error;
+                            } else {
+                                $this->context->cart->addCartRule($cartRule->id);
+                                CartRule::autoAddToCart($this->context);
+                                if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 1) {
+                                    Tools::redirect('index.php?controller=order-opc&addingCartRule=1');
+                                }
+                                Tools::redirect('index.php?controller=order&addingCartRule=1');
+                            }
+                        } else {
+                            $this->errors[] = Tools::displayError('This voucher does not exists.');
+                        }
+                    }
+                    $this->context->smarty->assign(array(
+                        'errors' => $this->errors,
+                        'discount_name' => Tools::safeOutput($code)
+                    ));
+                } elseif (($id_cart_rule = (int)Tools::getValue('deleteDiscount')) && Validate::isUnsignedId($id_cart_rule)) {
+                    $this->context->cart->removeCartRule($id_cart_rule);
+                    CartRule::autoAddToCart($this->context);
+                    Tools::redirect('index.php?controller=order-opc');
+                }
+            }
+            /* Is there only virtual product in cart */
+            if ($isVirtualCart = $this->context->cart->isVirtualCart()) {
+                $this->setNoCarrier();
+            }
+        }
+
+        $this->context->smarty->assign('back', Tools::safeOutput(Tools::getValue('back')));
     }
 
     public function initContent()
     {
-        parent::initContent();
+        if ($this->isInquiryMode()) {
+            parent::initContent();
 
-        if (!$this->isInquiryMode()) {
-            Tools::redirect($this->context->link->getPageLink('index', true));
+            $this->context->smarty->assign(array(
+                'inquiry_link' => $this->getInquiryLink(),
+            ));
+
+            $this->setTemplate('checkout-inquiry.tpl');
+
             return;
         }
 
+        parent::initContent();
+    }
+
+    public function setMedia()
+    {
+        parent::setMedia();
+
+        if (!$this->useMobileTheme()) {
+            // Adding CSS style sheet
+            $this->addCSS(_THEME_CSS_DIR_.'addresses.css');
+        }
+
+        // Adding JS files
+        $this->addJS(_THEME_JS_DIR_.'tools.js');  // retro compat themes 1.5
+        if ((Configuration::get('PS_ORDER_PROCESS_TYPE') == 0 && Tools::getValue('step') == 1) || Configuration::get('PS_ORDER_PROCESS_TYPE') == 1) {
+            $this->addJS(_THEME_JS_DIR_.'order-address.js');
+        }
+        $this->addJqueryPlugin('fancybox');
+
+        if (in_array((int)Tools::getValue('step'), array(0, 2, 3)) || Configuration::get('PS_ORDER_PROCESS_TYPE')) {
+            $this->addJqueryPlugin('typewatch');
+            $this->addJS(_THEME_JS_DIR_.'cart-summary.js');
+        }
+    }
+
+    /**
+     * Check if order is free
+     * @return bool
+     */
+    protected function _checkFreeOrder()
+    {
+        // let see if any due amount for order status
+        $dueAmount = 0;
+        // check if customer has chosen advance payment option for this cart
+        if ($this->context->cart->is_advance_payment) {
+            $orderTotal = $this->context->cart->getOrderTotal(true, CART::ADVANCE_PAYMENT);
+            $dueAmount = ($this->context->cart->getOrderTotal() - $orderTotal);
+        } else {
+            $orderTotal = $this->context->cart->getOrderTotal();
+        }
+        if ($orderTotal <= 0) {
+            $order = new FreeOrder();
+            $order->free_order_class = true;
+
+            // order status payment accepted if no amount is pending for the booking
+            if ($dueAmount > 0) {
+                $orderStatus = Configuration::get('PS_OS_AWAITING_PAYMENT');
+            } else {
+                $orderStatus = Configuration::get('PS_OS_PAYMENT_ACCEPTED');
+            }
+
+            $order->validateOrder($this->context->cart->id, $orderStatus, 0, $order->displayName, null, array(), null, false, $this->context->cart->secure_key);
+            return (int)Order::getOrderByCartId($this->context->cart->id);
+        }
+        return false;
+    }
+
+    protected function _updateMessage($messageContent)
+    {
+        if ($messageContent) {
+            if (!Validate::isMessage($messageContent)) {
+                $this->errors[] = Tools::displayError('Invalid message');
+            } elseif ($oldMessage = Message::getMessageByCartId((int)$this->context->cart->id)) {
+                $message = new Message((int)$oldMessage['id_message']);
+                $message->message = $messageContent;
+                $message->update();
+            } else {
+                $message = new Message();
+                $message->message = $messageContent;
+                $message->id_cart = (int)$this->context->cart->id;
+                $message->id_customer = (int)$this->context->cart->id_customer;
+                $message->add();
+            }
+        } else {
+            if ($oldMessage = Message::getMessageByCartId($this->context->cart->id)) {
+                $message = new Message($oldMessage['id_message']);
+                $message->delete();
+            }
+        }
+        return true;
+    }
+
+    protected function _processCarrier()
+    {
+        $this->context->cart->recyclable = (int)Tools::getValue('recyclable');
+        $this->context->cart->gift = (int)Tools::getValue('gift');
+        if ((int)Tools::getValue('gift')) {
+            if (!Validate::isMessage(Tools::getValue('gift_message'))) {
+                $this->errors[] = Tools::displayError('Invalid gift message.');
+            } else {
+                $this->context->cart->gift_message = strip_tags(Tools::getValue('gift_message'));
+            }
+        }
+
+        if (isset($this->context->customer->id) && $this->context->customer->id) {
+            $address = new Address((int)$this->context->cart->id_address_delivery);
+            if (!($id_zone = Address::getZoneById($address->id))) {
+                $this->errors[] = Tools::displayError('No zone matches your address.');
+            }
+        } else {
+            $id_zone = (int)Country::getIdZone((int)Tools::getCountry());
+        }
+
+        if (Tools::getIsset('delivery_option')) {
+            if ($this->validateDeliveryOption(Tools::getValue('delivery_option'))) {
+                $this->context->cart->setDeliveryOption(Tools::getValue('delivery_option'));
+            }
+        } elseif (Tools::getIsset('id_carrier')) {
+            // For retrocompatibility reason, try to transform carrier to an delivery option list
+            $delivery_option_list = $this->context->cart->getDeliveryOptionList();
+            if (count($delivery_option_list) == 1) {
+                $delivery_option = reset($delivery_option_list);
+                $key = Cart::desintifier(Tools::getValue('id_carrier'));
+                foreach ($delivery_option_list as $id_address => $options) {
+                    if (isset($options[$key])) {
+                        $this->context->cart->id_carrier = (int)Tools::getValue('id_carrier');
+                        $this->context->cart->setDeliveryOption(array($id_address => $key));
+                        if (isset($this->context->cookie->id_country)) {
+                            unset($this->context->cookie->id_country);
+                        }
+                        if (isset($this->context->cookie->id_state)) {
+                            unset($this->context->cookie->id_state);
+                        }
+                    }
+                }
+            }
+        }
+
+        Hook::exec('actionCarrierProcess', array('cart' => $this->context->cart));
+
+        if (!$this->context->cart->update()) {
+            return false;
+        }
+
+        // Carrier has changed, so we check if the cart rules still apply
+        CartRule::autoRemoveFromCart($this->context);
+        CartRule::autoAddToCart($this->context);
+
+        return true;
+    }
+
+    /**
+     * Validate get/post param delivery option
+     *
+     * @param array $delivery_option
+     *
+     * @return bool
+     */
+    protected function validateDeliveryOption($delivery_option)
+    {
+        if (!is_array($delivery_option)) {
+            return false;
+        }
+
+        foreach ($delivery_option as $option) {
+            if (!preg_match('/(\d+,)?\d+/', $option)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function _assignCheckoutVars()
+    {
+        $show_option_allow_separate_package = (!$this->context->cart->isAllProductsInStock(true) && Configuration::get('PS_SHIP_WHEN_AVAILABLE'));
+        $advanced_payment_api = (bool)Configuration::get('PS_ADVANCED_PAYMENT_API');
         $this->context->smarty->assign(array(
-            'inquiry_link' => $this->getInquiryLink(),
+            'THEME_DIR' => _THEME_DIR_,
+            'PS_ROOM_PRICE_AUTO_ADD_BREAKDOWN' => Configuration::get('PS_ROOM_PRICE_AUTO_ADD_BREAKDOWN'),
+            'show_option_allow_separate_package' => $show_option_allow_separate_package,
+            'advanced_payment_api' => $advanced_payment_api
+        ));
+    }
+
+    protected function _assignCheckoutValidationVars()
+    {
+        if ($orderRestrictErr = HotelCartBookingData::validateCartBookings()) {
+            $this->errors = array_merge($this->errors, $orderRestrictErr);
+        }
+        $this->context->smarty->assign(array(
+            'orderRestrictErr' => count($orderRestrictErr) ? 1 : 0,
+        ));
+    }
+
+    protected function _assignShoppingCart()
+    {
+        $summary = $this->context->cart->getSummaryDetails();
+        $cartProducts = $this->context->cart->getProducts();
+        if (!empty($cartProducts)) {
+
+            if ($cartBookingInfo = HotelCartBookingData::getHotelCartBookingData()) {
+                $this->context->smarty->assign('cart_htl_data', $cartBookingInfo);
+            }
+            $objServiceProductCartDetail = new ServiceProductCartDetail();
+            if ($hotelProducts = $objServiceProductCartDetail->getServiceProductsInCart(
+                $this->context->cart->id,
+                [Product::SELLING_PREFERENCE_HOTEL_STANDALONE, Product::SELLING_PREFERENCE_HOTEL_STANDALONE_AND_WITH_ROOM_TYPE],
+                $idHotel = null,
+                0,
+                null,
+                null,
+                null,
+                null,
+                0,
+                null,
+                0,
+                null,
+                1
+            )) {
+                $this->context->smarty->assign('hotel_products', $hotelProducts);
+            }
+
+            $standaloneProducts = $objServiceProductCartDetail->getServiceProductsInCart(
+                $this->context->cart->id,
+                [Product::SELLING_PREFERENCE_STANDALONE]
+            );
+
+            if (count($standaloneProducts)) {
+                $this->context->smarty->assign('standalone_products', $standaloneProducts);
+            }
+
+
+            // For Advanced Payment work
+            $objAdvPayment = new HotelAdvancedPayment();
+            if ($objAdvPayment->isAdvancePaymentAvailableForCurrentCart()) {
+                if (Tools::isSubmit('submitAdvPayment')) {
+                    if (Tools::getValue('payment_type') == Order::ORDER_PAYMENT_TYPE_ADVANCE) {
+                        $this->context->cart->is_advance_payment = 1;
+                    } else {
+                        $this->context->cart->is_advance_payment = 0;
+                    }
+                    $this->context->cart->save();
+
+                    Tools::redirect($this->context->link->getPageLink('order-opc'));
+                }
+
+                // set if advance payment is selected by the customer
+                if ($this->context->cart->is_advance_payment) {
+                    $this->context->smarty->assign('is_advance_payment', 1);
+                }
+
+                // get advance payment amount and send data to the template
+                $advPaymentAmount = $this->context->cart->getOrderTotal(true, Cart::ADVANCE_PAYMENT);
+                $this->context->smarty->assign(array(
+                    'advance_payment_active'=> 1,
+                    'advPaymentAmount'=> $advPaymentAmount,
+                    'dueAmount'=> ($this->context->cart->getOrderTotal() - $advPaymentAmount),
+                ));
+            }
+        }
+        $this->context->smarty->assign($summary);
+        $this->context->smarty->assign(array(
+            'HOOK_SHOPPING_CART' => Hook::exec('displayShoppingCartFooter', $summary),
+            'HOOK_SHOPPING_CART_EXTRA' => Hook::exec('displayShoppingCart', $summary)
+        ));
+    }
+
+    protected function _assignSummaryInformations()
+    {
+        $summary = $this->context->cart->getSummaryDetails();
+        $customizedDatas = Product::getAllCustomizedDatas($this->context->cart->id);
+
+        // override customization tax rate with real tax (tax rules)
+        if ($customizedDatas) {
+            foreach ($summary['products'] as &$productUpdate) {
+                $productId = (int)isset($productUpdate['id_product']) ? $productUpdate['id_product'] : $productUpdate['product_id'];
+                $productAttributeId = (int)isset($productUpdate['id_product_attribute']) ? $productUpdate['id_product_attribute'] : $productUpdate['product_attribute_id'];
+
+                if (isset($customizedDatas[$productId][$productAttributeId])) {
+                    $productUpdate['tax_rate'] = Tax::getProductTaxRate($productId, Cart::getIdAddressForTaxCalculation($productId));
+                }
+            }
+
+            Product::addCustomizationPrice($summary['products'], $customizedDatas);
+        }
+
+        $cart_product_context = Context::getContext()->cloneContext();
+        foreach ($summary['products'] as $key => &$product) {
+            $product['quantity'] = $product['cart_quantity'];// for compatibility with 1.2 themes
+
+            if ($cart_product_context->shop->id != $product['id_shop']) {
+                $cart_product_context->shop = new Shop((int)$product['id_shop']);
+            }
+            $product['price_without_specific_price'] = Product::getPriceStatic(
+                $product['id_product'],
+                !Product::getTaxCalculationMethod(),
+                $product['id_product_attribute'],
+                6,
+                null,
+                false,
+                false,
+                1,
+                false,
+                null,
+                null,
+                null,
+                $null,
+                true,
+                true,
+                $cart_product_context);
+
+            if (Product::getTaxCalculationMethod()) {
+                $product['is_discounted'] = Tools::ps_round($product['price_without_specific_price'], _PS_PRICE_COMPUTE_PRECISION_) != Tools::ps_round($product['price'], _PS_PRICE_COMPUTE_PRECISION_);
+            } else {
+                $product['is_discounted'] = Tools::ps_round($product['price_without_specific_price'], _PS_PRICE_COMPUTE_PRECISION_) != Tools::ps_round($product['price_wt'], _PS_PRICE_COMPUTE_PRECISION_);
+            }
+        }
+
+        // Get available cart rules and unset the cart rules already in the cart
+        $available_cart_rules = CartRule::getCustomerCartRules($this->context->language->id, (isset($this->context->customer->id) ? $this->context->customer->id : 0), true, true, true, $this->context->cart, false, true);
+        $cart_cart_rules = $this->context->cart->getCartRules();
+        foreach ($available_cart_rules as $key => $available_cart_rule) {
+            foreach ($cart_cart_rules as $cart_cart_rule) {
+                if ($available_cart_rule['id_cart_rule'] == $cart_cart_rule['id_cart_rule']) {
+                    unset($available_cart_rules[$key]);
+                    continue 2;
+                }
+            }
+        }
+
+        $this->context->smarty->assign($summary);
+        $this->context->smarty->assign(array(
+            'token_cart' => Tools::getToken(false),
+            'isLogged' => $this->isLogged,
+            'isVirtualCart' => $this->context->cart->isVirtualCart(),
+            'productNumber' => $this->context->cart->nbProducts(),
+            'voucherAllowed' => CartRule::isFeatureActive(),
+            'shippingCost' => $this->context->cart->getOrderTotal(true, Cart::ONLY_SHIPPING),
+            'shippingCostTaxExc' => $this->context->cart->getOrderTotal(false, Cart::ONLY_SHIPPING),
+            'customizedDatas' => $customizedDatas,
+            'CUSTOMIZE_FILE' => Product::CUSTOMIZE_FILE,
+            'CUSTOMIZE_TEXTFIELD' => Product::CUSTOMIZE_TEXTFIELD,
+            'lastProductAdded' => $this->context->cart->getLastProduct(),
+            'displayVouchers' => $available_cart_rules,
+            'smallSize' => Image::getSize(ImageType::getFormatedName('small')),
+
         ));
 
-        $this->setTemplate('checkout-inquiry.tpl');
+        $this->context->smarty->assign(array(
+            'HOOK_SHOPPING_CART' => Hook::exec('displayShoppingCartFooter', $summary),
+            'HOOK_SHOPPING_CART_EXTRA' => Hook::exec('displayShoppingCart', $summary)
+        ));
+    }
+
+    protected function _assignAddress()
+    {
+        //if guest checkout disabled and flag is_guest  in cookies is actived
+        if (Configuration::get('PS_GUEST_CHECKOUT_ENABLED') == 0 && ((int)$this->context->customer->is_guest != Configuration::get('PS_GUEST_CHECKOUT_ENABLED'))) {
+            $this->context->customer->logout();
+            Tools::redirect('');
+        } elseif (!Customer::getAddressesTotalById($this->context->customer->id)) {
+            $objServiceProductCartDetail = new ServiceProductCartDetail();
+            if (count($objServiceProductCartDetail->getServiceProductsInCart(
+                $this->context->cart->id,
+                [Product::SELLING_PREFERENCE_STANDALONE]
+            ))) {
+                $multi = (int)Tools::getValue('multi-shipping');
+                Tools::redirect('index.php?controller=address&back='.urlencode('order.php?step=1'.($multi ? '&multi-shipping='.$multi : '')));
+            }
+        }
+
+        $customer = $this->context->customer;
+        if (Validate::isLoadedObject($customer)) {
+            /* Getting customer addresses */
+            if ($customerAddresses = $customer->getAddresses($this->context->language->id)) {
+                // Getting a list of formated address fields with associated values
+                $formatedAddressFieldsValuesList = array();
+
+                foreach ($customerAddresses as $i => $address) {
+                    if (!Address::isCountryActiveById((int)$address['id_address'])) {
+                        unset($customerAddresses[$i]);
+                    }
+                    $tmpAddress = new Address($address['id_address']);
+                    $formatedAddressFieldsValuesList[$address['id_address']]['ordered_fields'] = AddressFormat::getOrderedAddressFields($address['id_country']);
+                    $formatedAddressFieldsValuesList[$address['id_address']]['formated_fields_values'] = AddressFormat::getFormattedAddressFieldsValues(
+                        $tmpAddress,
+                        $formatedAddressFieldsValuesList[$address['id_address']]['ordered_fields']);
+
+                    unset($tmpAddress);
+                }
+
+                $customerAddresses = array_values($customerAddresses);
+
+                $this->context->smarty->assign(array(
+                    'addresses' => $customerAddresses,
+                    'formatedAddressFieldsValuesList' => $formatedAddressFieldsValuesList)
+                );
+            }
+
+            /* Setting default addresses for cart */
+            if (count($customerAddresses)) {
+                if ((!isset($this->context->cart->id_address_invoice) || empty($this->context->cart->id_address_invoice)) || !Address::isCountryActiveById((int)$this->context->cart->id_address_invoice)) {
+                    $this->context->cart->id_address_invoice = (int)$customerAddresses[0]['id_address'];
+                    $update = 1;
+                }
+
+                /* Update cart addresses only if needed */
+                if (isset($update) && $update) {
+                    $this->context->cart->update();
+                    if (!$this->context->cart->isMultiAddressDelivery()) {
+                        $this->context->cart->setNoMultishipping();
+                    }
+                    // Address has changed, so we check if the cart rules still apply
+                    CartRule::autoRemoveFromCart($this->context);
+                    CartRule::autoAddToCart($this->context);
+                }
+            }
+
+            /* If delivery address is valid in cart, assign it to Smarty */
+            if (isset($this->context->cart->id_address_delivery)) {
+                $deliveryAddress = new Address((int)$this->context->cart->id_address_delivery);
+                if (Validate::isLoadedObject($deliveryAddress) && ($deliveryAddress->id_customer == $customer->id)) {
+                    $this->context->smarty->assign('delivery', $deliveryAddress);
+                }
+            }
+
+            /* If invoice address is valid in cart, assign it to Smarty */
+            if (isset($this->context->cart->id_address_invoice)) {
+                $invoiceAddress = new Address((int)$this->context->cart->id_address_invoice);
+                if (Validate::isLoadedObject($invoiceAddress) && ($invoiceAddress->id_customer == $customer->id)) {
+                    $this->context->smarty->assign('invoice', $invoiceAddress);
+                }
+            }
+        }
+        if ($oldMessage = Message::getMessageByCartId((int)$this->context->cart->id)) {
+            $this->context->smarty->assign('oldMessage', $oldMessage['message']);
+        }
+    }
+
+    protected function _assignCarrier()
+    {
+        $carriers = $this->context->cart->simulateCarriersOutput(null, true);
+        $checked = $this->context->cart->simulateCarrierSelectedOutput(false);
+        $delivery_option_list = $this->context->cart->getDeliveryOptionList();
+        $delivery_option = $this->context->cart->getDeliveryOption(null, false);
+        $this->setDefaultCarrierSelection($delivery_option_list);
+
+        $this->context->smarty->assign(array(
+            'address_collection' => $this->context->cart->getAddressCollection(),
+            'delivery_option_list' => $delivery_option_list,
+            'carriers' => $carriers,
+            'checked' => $checked,
+            'delivery_option' => $delivery_option
+        ));
+
+        $advanced_payment_api = (bool)Configuration::get('PS_ADVANCED_PAYMENT_API');
+
+        $vars = array(
+            'HOOK_BEFORECARRIER' => Hook::exec('displayBeforeCarrier', array(
+                'carriers' => $carriers,
+                'checked' => $checked,
+                'delivery_option_list' => $delivery_option_list,
+                'delivery_option' => $delivery_option
+            )),
+            'advanced_payment_api' => $advanced_payment_api
+        );
+
+        Cart::addExtraCarriers($vars);
+
+        $this->context->smarty->assign($vars);
+    }
+
+    protected function _assignWrappingAndTOS()
+    {
+        // Wrapping fees
+        $wrapping_fees = $this->context->cart->getGiftWrappingPrice(false);
+        $wrapping_fees_tax_inc = $this->context->cart->getGiftWrappingPrice();
+
+        // TOS
+        $cms = new CMS(Configuration::get('PS_CONDITIONS_CMS_ID'), $this->context->language->id);
+        $this->link_conditions = $this->context->link->getCMSLink($cms, $cms->link_rewrite, (bool)Configuration::get('PS_SSL_ENABLED'));
+        if (!strpos($this->link_conditions, '?')) {
+            $this->link_conditions .= '?content_only=1';
+        } else {
+            $this->link_conditions .= '&content_only=1';
+        }
+
+        $free_shipping = false;
+        foreach ($this->context->cart->getCartRules() as $rule) {
+            if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
+                $free_shipping = true;
+                break;
+            }
+        }
+        $this->context->smarty->assign(array(
+            'free_shipping' => $free_shipping,
+            'checkedTOS' => (int)$this->context->cookie->checkedTOS,
+            'recyclablePackAllowed' => (int)Configuration::get('PS_RECYCLABLE_PACK'),
+            'giftAllowed' => (int)Configuration::get('PS_GIFT_WRAPPING'),
+            'cms_id' => (int)Configuration::get('PS_CONDITIONS_CMS_ID'),
+            'conditions' => (int)Configuration::get('PS_CONDITIONS'),
+            'link_conditions' => $this->link_conditions,
+            'recyclable' => (int)$this->context->cart->recyclable,
+            'delivery_option_list' => $this->context->cart->getDeliveryOptionList(),
+            'carriers' => $this->context->cart->simulateCarriersOutput(),
+            'checked' => $this->context->cart->simulateCarrierSelectedOutput(),
+            'address_collection' => $this->context->cart->getAddressCollection(),
+            'delivery_option' => $this->context->cart->getDeliveryOption(null, false),
+            'gift_wrapping_price' => (float)$wrapping_fees,
+            'total_wrapping_cost' => Tools::convertPrice($wrapping_fees_tax_inc, $this->context->currency),
+            'override_tos_display' => Hook::exec('overrideTOSDisplay'),
+            'total_wrapping_tax_exc_cost' => Tools::convertPrice($wrapping_fees, $this->context->currency)));
+    }
+
+    protected function _assignPayment()
+    {
+        if ((bool)Configuration::get('PS_ADVANCED_PAYMENT_API')) {
+            $this->addJS(_THEME_JS_DIR_.'advanced-payment-api.js');
+
+            // TOS
+            $cms = new CMS(Configuration::get('PS_CONDITIONS_CMS_ID'), $this->context->language->id);
+            $this->link_conditions = $this->context->link->getCMSLink($cms, $cms->link_rewrite, (bool)Configuration::get('PS_SSL_ENABLED'));
+            if (!strpos($this->link_conditions, '?')) {
+                $this->link_conditions .= '?content_only=1';
+            } else {
+                $this->link_conditions .= '&content_only=1';
+            }
+
+            $this->context->smarty->assign(array(
+                'HOOK_TOP_PAYMENT' => Hook::exec('displayPaymentTop'),
+                'HOOK_ADVANCED_PAYMENT' => Hook::exec('advancedPaymentOptions', array(), null, true),
+                'link_conditions' => $this->link_conditions
+            ));
+        } else {
+            $this->context->smarty->assign(array(
+                'HOOK_TOP_PAYMENT' => Hook::exec('displayPaymentTop'),
+                'HOOK_PAYMENT' => Hook::exec('displayPayment'),
+            ));
+        }
+    }
+
+    /**
+     * Set id_carrier to 0 (no shipping price)
+     */
+    protected function setNoCarrier()
+    {
+        $this->context->cart->setDeliveryOption(null);
+        $this->context->cart->update();
+    }
+
+    /**
+     * Decides what the default carrier is and update the cart with it
+     *
+     * @todo this function must be modified - id_carrier is now delivery_option
+     *
+     * @param array $carriers
+     *
+     * @deprecated since 1.5.0
+     *
+     * @return number the id of the default carrier
+     */
+    protected function setDefaultCarrierSelection($carriers)
+    {
+        if (!$this->context->cart->getDeliveryOption(null, true)) {
+            $this->context->cart->setDeliveryOption($this->context->cart->getDeliveryOption());
+        }
+    }
+
+    /**
+     * Decides what the default carrier is and update the cart with it
+     *
+     * @param array $carriers
+     *
+     * @deprecated since 1.5.0
+     *
+     * @return number the id of the default carrier
+     */
+    protected function _setDefaultCarrierSelection($carriers)
+    {
+        $this->context->cart->id_carrier = Carrier::getDefaultCarrierSelection($carriers, (int)$this->context->cart->id_carrier);
+
+        if ($this->context->cart->update()) {
+            return $this->context->cart->id_carrier;
+        }
+        return 0;
     }
 
     protected function getInquiryLink()

--- a/roadmap.md
+++ b/roadmap.md
@@ -3,7 +3,8 @@
 This roadmap tracks how the Kunstort Lehnin fork evolves from a de-bloated QloApps baseline into a residency-first operations suite. Each phase groups together coherent deliverables so we can prioritise work and spot dependencies early. Status markers: ✅ complete, 🚧 in progress, ⏳ planned.
 
 ## Phase 0 – Commerce Debloating (✅ Complete)
-- ✅ **Checkout short-circuit** – `order`/`order-opc` controllers render the inquiry landing and the matching theme templates only display the manual booking guidance.
+- ✅ **Checkout short-circuit** – when inquiry mode is enabled, `order`/`order-opc` controllers redirect to the inquiry landing (AJAX calls receive friendly JSON errors) while the restored legacy controllers and templates ensure clearing the flag immediately revives the cart workflow without code edits.
+- ✅ **Cart hardening** – inquiry mode also blocks cart mutations so direct POSTs cannot create ghost carts while the distribution runs inquiry-first.
 - ✅ **Payment modules removed** – legacy `bankwire`, `cheque` and `qlopaypalcommerce` modules (and overrides) are no longer shipped so no unused PCI-facing code stays in the tree.
 - ✅ **Front-office widgets stripped** – header and column slots now render a static residency navigation without cart, account, newsletter or social hooks.
 - ✅ **Webservice disabled** – `/webservice` responds with HTTP 410 and admin tooling for API keys has been excised to reduce attack surface.

--- a/themes/hotel-reservation-theme/cart-total-block.tpl
+++ b/themes/hotel-reservation-theme/cart-total-block.tpl
@@ -1,1 +1,147 @@
-{include file='_partials/checkout-inquiry-message.tpl'}
+{*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License version 3.0
+* that is bundled with this package in the file LICENSE.md
+* It is also available through the world-wide-web at this URL:
+* https://opensource.org/license/osl-3-0-php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to support@qloapps.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade this module to a newer
+* versions in the future. If you wish to customize this module for your needs
+* please refer to https://store.webkul.com/customisation-guidelines for more information.
+*
+* @author Webkul IN
+* @copyright Since 2010 Webkul
+* @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+*}
+
+
+<div class="col-sm-12 card cart_total_detail_block">
+    {if $total_rooms_wt + $total_extra_demands_wt + $total_additional_services_wt + $total_additional_services_auto_add_wt}
+        <p>
+            <span>
+                {l s='Total rooms cost'}
+                {if $display_tax_label}
+                    {if $use_taxes && $priceDisplay == 0}
+                        {l s='(tax incl)'}
+                    {else}
+                        {l s='(tax excl)'}
+                    {/if}
+                {/if}
+            </span>
+            <span class="cart_total_values">
+                {if $use_taxes && $priceDisplay == 0}
+                    {assign var='total_rooms_cost' value=($total_rooms_wt + $total_extra_demands_wt + $total_additional_services_wt + $total_additional_services_auto_add_wt)}
+                {else}
+                    {assign var='total_rooms_cost' value=($total_rooms + $total_extra_demands + $total_additional_services + $total_additional_services_auto_add)}
+                {/if}
+                {displayPrice price=$total_rooms_cost}
+            </span>
+        </p>
+    {/if}
+    {if $total_standalone_service_products}
+        <p>
+            <span>
+                {l s='Total products'}
+                {if $display_tax_label}
+                    {if $use_taxes && $priceDisplay == 0}
+                        {l s='(tax incl)'}
+                    {else}
+                        {l s='(tax excl)'}
+                    {/if}
+                {/if}
+            </span>
+            <span class="cart_total_values">
+                {if $use_taxes && $priceDisplay == 0}
+                    {displayPrice price=$total_standalone_service_products_wt}
+                {else}
+                    {displayPrice price=$total_standalone_service_products}
+                {/if}
+            </span>
+        </p>
+    {/if}
+    {if $convenience_fee_wt}
+        <p>
+            <span>
+                {l s='Convenience Fees'}
+                {if $display_tax_label}
+                    {if $use_taxes && $priceDisplay == 0}
+                        {l s='(tax incl)'}
+                    {else}
+                        {l s='(tax excl)'}
+                    {/if}
+                {/if}
+            </span>
+            <span class="cart_total_values">
+            {if $use_taxes && $priceDisplay == 0}
+                {displayPrice price=$convenience_fee_wt}
+            {else}
+                {displayPrice price=$convenience_fee}
+            {/if}
+            </span>
+        </p>
+    {/if}
+    {block name='displayBeforeCartTotalTax'}
+        {hook h='displayBeforeCartTotalTax'}
+    {/block}
+    {if $show_taxes}
+        <p class="cart_total_tax">
+            <span>{l s='Total tax'}</span>
+            <span class="cart_total_values">{displayPrice price=($total_tax_without_discount)}</span>
+        </p>
+    {/if}
+    <p class="total_discount_block {if $total_discounts == 0}unvisible{/if}">
+        <span>
+            {if $display_tax_label}
+                {if $use_taxes && $priceDisplay == 0}
+                    {l s='Total Discount (tax incl)'}
+                {else}
+                    {l s='Total Discount (tax excl)'}
+                {/if}
+            {else}
+                {l s='Total Discount'}
+            {/if}
+        </span>
+        <span class="cart_total_values">
+            {if $use_taxes && $priceDisplay == 0}
+                {assign var='total_discounts_negative' value=$total_discounts * -1}
+            {else}
+                {assign var='total_discounts_negative' value=$total_discounts_tax_exc * -1}
+            {/if}
+            {displayPrice price=$total_discounts_negative}
+        </span>
+    </p>
+        <hr>
+        <p {if !isset($is_advance_payment) || !$is_advance_payment}class="cart_final_total_block"{/if}>
+            <span class="strong">{l s='Total'}</span>
+            {block name='displayCartTotalPriceLabelTotal'}
+                {hook h="displayCartTotalPriceLabel" type='total'}
+            {/block}
+        <span class="cart_total_values {if isset($is_advance_payment) && $is_advance_payment} strong{/if}">
+                {if $use_taxes}
+                    {displayPrice price=$total_price}
+                {else}
+                    {displayPrice price=$total_price_without_tax}
+                {/if}
+            </span>
+        </p>
+        {if isset($is_advance_payment) && $is_advance_payment}
+            <hr>
+            <p>
+                <span>{l s='Due Amount'}</span>
+                <span class="cart_total_values">{displayPrice price=$dueAmount}</span>
+            </p>
+            <p class="cart_final_total_block">
+                <span class="strong">{l s='Partially Payable Total'}</span>
+                {block name='displayCartTotalPriceLabelPartial'}
+                    {hook h="displayCartTotalPriceLabel" type='partial'}
+                {/block}
+                <span class="cart_total_values">{displayPrice price=$advPaymentAmount}</span>
+            </p>
+        {/if}
+</div>

--- a/themes/hotel-reservation-theme/order-address-advanced.tpl
+++ b/themes/hotel-reservation-theme/order-address-advanced.tpl
@@ -1,1 +1,101 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+{assign var='have_non_virtual_products' value=false}
+{foreach $products as $product}
+    {if $product.is_virtual == 0}
+        {assign var='have_non_virtual_products' value=true}
+        {break}
+    {/if}
+{/foreach}
+<h2>{l s='Address(es) Details'}</h2>
+{if ((!empty($delivery_option) AND (!isset($isVirtualCart) || !$isVirtualCart)) OR $delivery->id OR $invoice->id)}
+    <div class="order_delivery clearfix row">
+        {if !isset($formattedAddresses) || (count($formattedAddresses.invoice) == 0 && count($formattedAddresses.delivery) == 0) || (count($formattedAddresses.invoice.formated) == 0 && count($formattedAddresses.delivery.formated) == 0)}
+            {if $delivery->id}
+                <div class="col-xs-12 col-sm-6"{if !$have_non_virtual_products} style="display: none;"{/if}>
+                    <ul id="delivery_address" class="address item box">
+                        <li><h3 class="page-subheading">{l s='Delivery address'}&nbsp;<span class="address_alias">({$delivery->alias})</span></h3></li>
+                        {if $delivery->company}<li class="address_company">{$delivery->company|escape:'html':'UTF-8'}</li>{/if}
+                        <li class="address_name">{$delivery->firstname|escape:'html':'UTF-8'} {$delivery->lastname|escape:'html':'UTF-8'}</li>
+                        <li class="address_address1">{$delivery->address1|escape:'html':'UTF-8'}</li>
+                        {if $delivery->address2}<li class="address_address2">{$delivery->address2|escape:'html':'UTF-8'}</li>{/if}
+                        <li class="address_city">{$delivery->postcode|escape:'html':'UTF-8'} {$delivery->city|escape:'html':'UTF-8'}</li>
+                        <li class="address_country">{$delivery->country|escape:'html':'UTF-8'} {if $delivery->id_state }({$delivery_state->name|escape:'html':'UTF-8'}){/if}</li>
+                    </ul>
+                </div>
+            {/if}
+            {if $invoice->id}
+                <div class="col-xs-12 col-sm-6">
+                    <ul id="invoice_address" class="address alternate_item box">
+                        <li><h3 class="page-subheading">{l s='Invoice address'}&nbsp;<span class="address_alias">({$invoice->alias})</span></h3></li>
+                        {if $invoice->company}<li class="address_company">{$invoice->company|escape:'html':'UTF-8'}</li>{/if}
+                        <li class="address_name">{$invoice->firstname|escape:'html':'UTF-8'} {$invoice->lastname|escape:'html':'UTF-8'}</li>
+                        <li class="address_address1">{$invoice->address1|escape:'html':'UTF-8'}</li>
+                        {if $invoice->address2}<li class="address_address2">{$invoice->address2|escape:'html':'UTF-8'}</li>{/if}
+                        <li class="address_city">{$invoice->postcode|escape:'html':'UTF-8'} {$invoice->city|escape:'html':'UTF-8'}</li>
+                        <li class="address_country">{$invoice->country|escape:'html':'UTF-8'} {if $invoice->id_state}({$invoice->name|escape:'html':'UTF-8'}){/if}</li>
+                    </ul>
+                </div>
+            {/if}
+        {else}
+            {foreach from=$formattedAddresses key=k item=address}
+                <div class="col-xs-12 col-sm-6"{if $k == 'delivery' && !$have_non_virtual_products} style="display: none;"{/if}>
+                    <ul class="address {if $address@last}last_item{elseif $address@first}first_item{/if} {if $address@index % 2}alternate_item{else}item{/if} box">
+                        <li>
+                            <h3 class="page-subheading">
+                                {if $k eq 'invoice'}
+                                    {l s='Invoice address'}
+                                {elseif $k eq 'delivery' && $delivery->id}
+                                    {l s='Delivery address'}
+                                {/if}
+                                {if isset($address.object.alias)}
+                                    <span class="address_alias">({$address.object.alias})</span>
+                                {/if}
+                            </h3>
+                        </li>
+                        {foreach $address.ordered as $pattern}
+                            {assign var=addressKey value=" "|explode:$pattern}
+                            {assign var=addedli value=false}
+                            {foreach from=$addressKey item=key name=foo}
+                                {$key_str = $key|regex_replace:AddressFormat::_CLEANING_REGEX_:""}
+                                {if isset($address.formated[$key_str]) && !empty($address.formated[$key_str])}
+                                    {if (!$addedli)}
+                                        {$addedli = true}
+                                        <li><span class="{if isset($addresses_style[$key_str])}{$addresses_style[$key_str]}{/if}">
+                                    {/if}
+                                    {$address.formated[$key_str]|escape:'html':'UTF-8'}
+                                {/if}
+                                {if ($smarty.foreach.foo.last && $addedli)}
+                                    </span></li>
+                                {/if}
+                            {/foreach}
+                        {/foreach}
+                    </ul>
+                </div>
+            {/foreach}
+        {/if}
+    </div>
+{/if}
+

--- a/themes/hotel-reservation-theme/order-address-multishipping-products.tpl
+++ b/themes/hotel-reservation-theme/order-address-multishipping-products.tpl
@@ -1,1 +1,53 @@
-{include file='_partials/checkout-inquiry-message.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @version  Release: $Revision$
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+<p class="info-title">{l s='Choose the delivery addresses'}</p>
+<div id="order-detail-content" class="table_block table-responsive">
+	<table id="cart_summary" class="table table-bordered multishipping-cart">
+		<thead>
+			<tr>
+				<th class="cart_product first_item">{l s='Product'}</th>
+				<th class="cart_description item">{l s='Description'}</th>
+				<th class="cart_ref item">{l s='Ref.'}</th>
+                <th class="cart_avail item">{l s='Avail.'}</th>
+				<th class="cart_quantity item">{l s='Qty'}</th>
+				<th class="shipping_address last_item">{l s='Shipping address'}</th>
+			</tr>
+		</thead>
+		<tbody>
+		{foreach $product_list as $product}
+			{assign var='productId' value=$product.id_product}
+			{assign var='productAttributeId' value=$product.id_product_attribute}
+			{assign var='quantityDisplayed' value=0}
+			{assign var='odd' value=$product@iteration%2}
+			{* Display the product line *}
+			{include file="$tpl_dir./order-address-product-line.tpl" productLast=$product@last productFirst=$product@first}
+		{/foreach}
+		</tbody>
+	</table>
+</div>
+{addJsDefL name=CloseTxt}{l s='Submit' js=1}{/addJsDefL}
+{addJsDefL name=QtyChanged}{l s='Some product quantities have changed. Please check them' js=1}{/addJsDefL}
+{addJsDefL name=ShipToAnOtherAddress}{l s='Ship to multiple addresses' js=1}{/addJsDefL}

--- a/themes/hotel-reservation-theme/order-address-multishipping.tpl
+++ b/themes/hotel-reservation-theme/order-address-multishipping.tpl
@@ -1,1 +1,112 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @version  Release: $Revision$
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+{if !$opc}
+	{assign var='current_step' value='address'}
+	{capture name=path}{l s='Addresses'}{/capture}
+	{assign var="back_order_page" value="order.php"}
+	<h1 class="page-heading">{l s='Addresses'}</h1>
+	{include file="$tpl_dir./order-steps.tpl"}
+	{include file="$tpl_dir./errors.tpl"}
+	{include file="$tpl_dir./order-address-multishipping-products.tpl"}
+		<form action="{$link->getPageLink('order', true, NULL, 'multi-shipping=1')|escape:'html':'UTF-8'}" method="post">
+{else}
+	{assign var="back_order_page" value="order-opc.php"}
+	<h1 class="page-heading step-num"><span>1</span> {l s='Addresses'}</h1>
+	<div id="opc_account" class="opc-main-block">
+		<div id="opc_account-overlay" class="opc-overlay" style="display: none;"></div>
+{/if}
+<div class="addresses clearfix">
+	<input type="hidden" name="id_address_delivery" id="id_address_delivery" value="{$cart->id_address_delivery}"/>
+	<p id="address_invoice_form" class="select" {if $cart->id_address_invoice == $cart->id_address_delivery}style="display: none;"{/if}>
+	
+	{if $addresses|@count >= 1}
+    <div class="form-group selector1">
+		<label for="id_address_invoice" class="strong">{l s='Choose a billing address:'}</label>
+		<select name="id_address_invoice" id="id_address_invoice" class="address_select form-control">
+		{section loop=$addresses step=-1 name=address}
+			<option value="{$addresses[address].id_address|intval}" {if $addresses[address].id_address == $cart->id_address_invoice && $cart->id_address_delivery != $cart->id_address_invoice}selected="selected"{/if}>{$addresses[address].alias|escape:'html':'UTF-8'}</option>
+		{/section}
+		</select>
+    </div>
+	{else}
+		<a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{'&multi-shipping=1'|urlencode}{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default"><span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span></a>
+	{/if}
+	</p>
+	<div class="row">
+    	<div class="col-sm-12 col-md-6">
+            <ul class="address alternate_item {if $cart->isVirtualCart()}full_width{/if} box" id="address_invoice">
+            </ul>
+        </div>
+	</div>
+	<p class="address_add submit">
+		<a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{'&multi-shipping=1'|urlencode}{if $back}&mod={$back|urlencode}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default"><span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span></a>
+	</p>
+	{if !$opc}
+	<div id="ordermsg" class="form-group">
+		<label>{l s='If you would like to add a comment about your order, please write it in the field below.'}</label>
+		<textarea class="form-control" cols="60" rows="6" name="message">{if isset($oldMessage)}{$oldMessage}{/if}</textarea>
+	</div>
+	{/if}
+</div>
+{if !$opc}
+			<p class="cart_navigation clearfix">
+				<input type="hidden" class="hidden" name="step" value="2" />
+				<input type="hidden" name="back" value="{$back}" />
+				{if $back}
+					<a href="{$link->getPageLink('order', true, NULL, "back={$back}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default"><i class="icon-chevron-left"></i>{l s='Continue Shopping'}</a>
+				{else}
+					<a href="{$link->getPageLink('order', true, NULL)|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default"><i class="icon-chevron-left"></i>{l s='Continue Shopping'}</a>
+				{/if}
+		        <button type="submit" name="processAddress" class="button btn btn-default button-medium"><span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span></button>
+			</p>
+		</form>
+{else}
+	</div>
+{/if}
+{strip}
+{if !$opc}
+	{addJsDef orderProcess='order'}
+	{addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
+	{addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
+	{addJsDefL name=CloseTxt}{l s='Submit' js=1}{/addJsDefL}
+	{addJsDefL name=txtSelectAnAddressFirst}{l s='Please start by selecting an address' js=1}{/addJsDefL}
+{/if}
+{capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
+{capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
+{addJsDef addressUrl=$smarty.capture.addressUrl}
+{capture}{'&multi-shipping=1'|urlencode}{/capture}
+{addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
+{capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
+{addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
+{addJsDef formatedAddressFieldsValuesList=$formatedAddressFieldsValuesList}
+{addJsDef opc=$opc|boolval}
+{capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
+{addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+{capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
+{addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+{capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
+{addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+{/strip}

--- a/themes/hotel-reservation-theme/order-address-product-line.tpl
+++ b/themes/hotel-reservation-theme/order-address-product-line.tpl
@@ -1,1 +1,78 @@
-{include file='_partials/checkout-inquiry-message.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @version  Release: $Revision$
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+<tr id="product_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" class="{if $productLast}last_item{elseif $productFirst}first_item{/if} {if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0}alternate_item{/if} cart_item {if $odd}odd{else}even{/if}">
+	<td class="cart_product">
+		<a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'small_default')|escape:'html':'UTF-8'}" alt="{$product.name|escape:'html':'UTF-8'}" {if isset($smallSize)}width="{$smallSize.width}" height="{$smallSize.height}" {/if} /></a>
+	</td>
+	<td class="cart_description">
+		<p class="product-name"><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}">{$product.name|escape:'html':'UTF-8'}</a></p>
+		{if isset($product.attributes) && $product.attributes}<small><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}">{$product.attributes|escape:'html':'UTF-8'}</a></small>{/if}
+	</td>
+	<td class="cart_ref">{if $product.reference}{$product.reference|escape:'html':'UTF-8'}{else}--{/if}</td>
+    <td class="cart_avail">{if $product.stock_quantity > 0}<span class="label label-success">{l s='In Stock'}</span>{else}<span class="label label-warning">{l s='Out of Stock'}</span>{/if}</td>
+	<td class="cart_quantity {if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0} text-center {/if}">
+	{if isset($cannotModify) AND $cannotModify == 1}
+		<span>{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}</span>
+	{else}
+		{if !isset($customizedDatas.$productId.$productAttributeId) OR $quantityDisplayed > 0}
+        	<input type="hidden" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}" name="quantity_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}_hidden" />
+			<input size="2" type="text" class="cart_quantity_input form-control grey" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}"  name="quantity_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" />
+			<div class="cart_quantity_button">
+			{if $product.minimal_quantity < ($product.cart_quantity-$quantityDisplayed) OR $product.minimal_quantity <= 1}
+			<a rel="nofollow" class="cart_quantity_down btn btn-default button-minus" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;op=down&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Subtract'}"><span><i class="icon-minus"></i></span></a>
+			{else}
+			<a class="cart_quantity_down btn btn-default button-minus disabled" href="#" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" title="{l s='You must purchase a minimum of %d of this product.' sprintf=$product.minimal_quantity}"><span><i class="icon-minus"></i></span></a>
+			{/if}
+            <a rel="nofollow" class="cart_quantity_up btn btn-default button-plus" id="cart_quantity_up_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Add'}"><span><i class="icon-plus"></i></span></a>
+			</div>
+		{/if}
+	{/if}
+	</td>
+	<td>
+		<form method="post" action="{$link->getPageLink('cart', true, NULL, "token={$token_cart}")|escape:'html':'UTF-8'}">
+        	<div class="selector2">
+                <input type="hidden" name="id_product" value="{$product.id_product}" />
+                <input type="hidden" name="id_product_attribute" value="{$product.id_product_attribute}" />
+                <select name="address_delivery" id="select_address_delivery_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}" class="cart_address_delivery form-control">
+                    {if $product.id_address_delivery == 0 && $delivery->id == 0}
+                    <option></option>
+                    {/if}
+                    <option value="-1">{l s='Create a new address'}</option>
+                    {foreach $address_list as $address}
+                        <option value="{$address.id_address}"
+                            {if ($product.id_address_delivery > 0 && $product.id_address_delivery == $address.id_address) || ($product.id_address_delivery == 0  && $address.id_address == $delivery->id)}
+                                selected="selected"
+                            {/if}
+                        >
+                            {$address.alias}
+                        </option>
+                    {/foreach}
+                    <option value="-2">{l s='Ship to multiple addresses'}</option>
+                </select>
+            </div>
+		</form>
+	</td>
+</tr>

--- a/themes/hotel-reservation-theme/order-address.tpl
+++ b/themes/hotel-reservation-theme/order-address.tpl
@@ -1,1 +1,139 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+{if !$opc}
+	{assign var='current_step' value='address'}
+	{capture name=path}{l s='Addresses'}{/capture}
+	{assign var="back_order_page" value="order.php"}
+	<h1 class="page-heading">{l s='Addresses'}</h1>
+	{include file="$tpl_dir./order-steps.tpl"}
+	{include file="$tpl_dir./errors.tpl"}
+		<form action="{$link->getPageLink($back_order_page, true)|escape:'html':'UTF-8'}" method="post">
+{else}
+	{assign var="back_order_page" value="order-opc.php"}
+	<h1 class="page-heading step-num"><span>1</span> {l s='Addresses'}</h1>
+	<div id="opc_account" class="opc-main-block">
+		<div id="opc_account-overlay" class="opc-overlay" style="display: none;"></div>
+{/if}
+<div class="addresses clearfix">
+	<div class="row">
+		<div class="col-xs-12 col-sm-6">
+			<div class="address_delivery select form-group selector1">
+				<label for="id_address_delivery">{if $cart->isVirtualCart()}{l s='Choose a billing address:'}{else}{l s='Choose a delivery address:'}{/if}</label>
+				<select name="id_address_delivery" id="id_address_delivery" class="address_select form-control">
+					{foreach from=$addresses key=k item=address}
+						<option value="{$address.id_address|intval}"{if $address.id_address == $cart->id_address_delivery} selected="selected"{/if}>
+							{$address.alias|escape:'html':'UTF-8'}
+						</option>
+					{/foreach}
+				</select><span class="waitimage"></span>
+			</div>
+			<p class="checkbox addressesAreEquals"{if $cart->isVirtualCart()} style="display:none;"{/if}>
+				<input type="checkbox" name="same" id="addressesAreEquals" value="1"{if $cart->id_address_invoice == $cart->id_address_delivery || $addresses|@count == 1} checked="checked"{/if} />
+				<label for="addressesAreEquals">{l s='Use the delivery address as the billing address.'}</label>
+			</p>
+		</div>
+		<div class="col-xs-12 col-sm-6">
+			<div id="address_invoice_form" class="select form-group selector1"{if $cart->id_address_invoice == $cart->id_address_delivery} style="display: none;"{/if}>
+				{if $addresses|@count > 1}
+					<label for="id_address_invoice" class="strong">{l s='Choose a billing address:'}</label>
+					<select name="id_address_invoice" id="id_address_invoice" class="address_select form-control">
+					{section loop=$addresses step=-1 name=address}
+						<option value="{$addresses[address].id_address|intval}"{if $addresses[address].id_address == $cart->id_address_invoice && $cart->id_address_delivery != $cart->id_address_invoice} selected="selected"{/if}>
+							{$addresses[address].alias|escape:'html':'UTF-8'}
+						</option>
+					{/section}
+					</select><span class="waitimage"></span>
+				{else}
+					<a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1&select_address=1{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default">
+						<span>
+							{l s='Add a new address'}
+							<i class="icon-chevron-right right"></i>
+						</span>
+					</a>
+				{/if}
+			</div>
+		</div>
+	</div> <!-- end row -->
+	<div class="row">
+		<div class="col-xs-12 col-sm-6"{if $cart->isVirtualCart()} style="display:none;"{/if}>
+			<ul class="address item box" id="address_delivery">
+			</ul>
+		</div>
+		<div class="col-xs-12 col-sm-6">
+			<ul class="address alternate_item{if $cart->isVirtualCart()} full_width{/if} box" id="address_invoice">
+			</ul>
+		</div>
+	</div> <!-- end row -->
+	<p class="address_add submit">
+		<a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default">
+			<span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span>
+		</a>
+	</p>
+	{if !$opc}
+		<div id="ordermsg" class="form-group">
+			<label>{l s='If you would like to add a comment about your order, please write it in the field below.'}</label>
+			<textarea class="form-control" cols="60" rows="6" name="message">{if isset($oldMessage)}{$oldMessage}{/if}</textarea>
+		</div>
+	{/if}
+</div> <!-- end addresses -->
+{if !$opc}
+			<p class="cart_navigation clearfix">
+				<input type="hidden" class="hidden" name="step" value="2" />
+				<input type="hidden" name="back" value="{$back}" />
+				<a href="{$link->getPageLink($back_order_page, true, NULL, "{if $back}back={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+					<i class="icon-chevron-left"></i>
+					{l s='Continue Shopping'}
+				</a>
+				<button type="submit" name="processAddress" class="button btn btn-default button-medium">
+					<span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span>
+				</button>
+			</p>
+		</form>
+{else}
+	</div> <!--  end opc_account -->
+{/if}
+{strip}
+{if !$opc}
+	{addJsDef orderProcess='order'}
+	{addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
+	{addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
+	{addJsDefL name=CloseTxt}{l s='Submit' js=1}{/addJsDefL}
+{/if}
+{capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
+{capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
+{addJsDef addressUrl=$smarty.capture.addressUrl}
+{capture}{'&multi-shipping=1'|urlencode}{/capture}
+{addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
+{capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
+{addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
+{addJsDef formatedAddressFieldsValuesList=$formatedAddressFieldsValuesList}
+{addJsDef opc=$opc|boolval}
+{capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
+{addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+{capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
+{addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+{capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
+{addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+{/strip}

--- a/themes/hotel-reservation-theme/order-carrier-advanced.tpl
+++ b/themes/hotel-reservation-theme/order-carrier-advanced.tpl
@@ -1,1 +1,420 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+{if !$opc}
+{capture name=path}{l s='Shipping:'}{/capture}
+{assign var='current_step' value='shipping'}
+<div id="carrier_area">
+    <h2>{l s='Shipping:'}</h2>
+    {include file="$tpl_dir./order-steps.tpl"}
+    {include file="$tpl_dir./errors.tpl"}
+    <form id="form" action="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" method="post" name="carrier_area">
+        {else}
+        <div id="carrier_area" class="opc-main-block">
+            <h2>{l s='Delivery methods'}</h2>
+            <div id="opc_delivery_methods" class="opc-main-block">
+                <div id="opc_delivery_methods-overlay" class="opc-overlay" style="display: none;"></div>
+                {/if}
+                <div class="order_carrier_content box">
+                    {if isset($virtual_cart) && $virtual_cart}
+                        <input id="input_virtual_carrier" class="hidden" type="hidden" name="id_carrier" value="0" />
+                    {else}
+                        <div id="HOOK_BEFORECARRIER">
+                            {if isset($carriers) && isset($HOOK_BEFORECARRIER)}
+                                {$HOOK_BEFORECARRIER}
+                            {/if}
+                        </div>
+                        {if isset($isVirtualCart) && $isVirtualCart}
+                            <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
+                        {else}
+                            <div class="delivery_options_address">
+                                {if isset($delivery_option_list)}
+                                    {foreach $delivery_option_list as $id_address => $option_list}
+                                        <p class="carrier_title">
+                                            {if isset($address_collection[$id_address])}
+                                                {l s='Choose a shipping option for this address:'} {$address_collection[$id_address]->alias}
+                                            {else}
+                                                {l s='Choose a shipping option'}
+                                            {/if}
+                                        </p>
+                                        <div class="delivery_options">
+                                            {foreach $option_list as $key => $option}
+                                                <div class="delivery_option {if ($option@index % 2)}alternate_{/if}item">
+                                                    <div>
+                                                        <table class="resume table table-bordered{if !$option.unique_carrier} hide{/if}">
+                                                            <tr>
+                                                                <td class="delivery_option_radio">
+                                                                    <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                                                                </td>
+                                                                <td class="delivery_option_logo">
+                                                                    {foreach $option.carrier_list as $carrier}
+                                                                        {if $carrier.logo}
+                                                                            <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                                                                        {elseif !$option.unique_carrier}
+                                                                            {$carrier.instance->name|escape:'htmlall':'UTF-8'}
+                                                                            {if !$carrier@last} - {/if}
+                                                                        {/if}
+                                                                    {/foreach}
+                                                                </td>
+                                                                <td>
+                                                                    {if $option.unique_carrier}
+                                                                        {foreach $option.carrier_list as $carrier}
+                                                                            <strong>{$carrier.instance->name|escape:'htmlall':'UTF-8'}</strong>
+                                                                        {/foreach}
+                                                                        {if isset($carrier.instance->delay[$cookie->id_lang])}
+                                                                            <br />{l s='Delivery time:'}&nbsp;{$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                                                        {/if}
+                                                                    {/if}
+                                                                    {if count($option_list) > 1}
+                                                                        <br />
+                                                                        {if $option.is_best_grade}
+                                                                            {if $option.is_best_price}
+                                                                                <span class="best_grade best_grade_price best_grade_speed">{l s='The best price and speed'}</span>
+                                                                            {else}
+                                                                                <span class="best_grade best_grade_speed">{l s='The fastest'}</span>
+                                                                            {/if}
+                                                                        {elseif $option.is_best_price}
+                                                                            <span class="best_grade best_grade_price">{l s='The best price'}</span>
+                                                                        {/if}
+                                                                    {/if}
+                                                                </td>
+                                                                <td class="delivery_option_price">
+                                                                    <div class="delivery_option_price">
+                                                                        {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                                                                            {if $use_taxes == 1}
+                                                                                {if $priceDisplay == 1}
+                                                                                    {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
+                                                                                {else}
+                                                                                    {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                                                                {/if}
+                                                                            {else}
+                                                                                {convertPrice price=$option.total_price_without_tax}
+                                                                            {/if}
+                                                                        {else}
+                                                                            {l s='Free'}
+                                                                        {/if}
+                                                                    </div>
+                                                                </td>
+                                                            </tr>
+                                                        </table>
+                                                        {if !$option.unique_carrier}
+                                                            <table class="delivery_option_carrier{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} selected{/if} resume table table-bordered{if $option.unique_carrier} hide{/if}">
+                                                                <tr>
+                                                                    {if !$option.unique_carrier}
+                                                                        <td rowspan="{$option.carrier_list|@count}" class="delivery_option_radio first_item">
+                                                                            <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                                                                        </td>
+                                                                    {/if}
+                                                                    {assign var="first" value=current($option.carrier_list)}
+                                                                    <td class="delivery_option_logo{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                                                        {if $first.logo}
+                                                                            <img class="order_carrier_logo" src="{$first.logo|escape:'htmlall':'UTF-8'}" alt="{$first.instance->name|escape:'htmlall':'UTF-8'}"/>
+                                                                        {elseif !$option.unique_carrier}
+                                                                            {$first.instance->name|escape:'htmlall':'UTF-8'}
+                                                                        {/if}
+                                                                    </td>
+                                                                    <td class="{if $option.unique_carrier}first_item{/if}{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                                                        <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                                                                        {if isset($first.instance->delay[$cookie->id_lang])}
+                                                                            <i class="icon-info-sign"></i>
+                                                                            {strip}
+                                                                                {$first.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                                                                &nbsp;
+                                                                                {if count($first.product_list) <= 1}
+                                                                                    ({l s='For this product:'}
+                                                                                {else}
+                                                                                    ({l s='For these products:'}
+                                                                                {/if}
+                                                                            {/strip}
+                                                                            {foreach $first.product_list as $product}
+                                                                                {if $product@index == 4}
+                                                                                    <acronym title="
+																{/if}
+																{strip}
+																	{if $product@index >= 4}
+																		{$product.name|escape:'htmlall':'UTF-8'}
+																		{if isset($product.attributes) && $product.attributes}
+																			{$product.attributes|escape:'htmlall':'UTF-8'}
+																		{/if}
+																		{if !$product@last}
+																			,&nbsp;
+																		{else}
+																			">&hellip;</acronym>)
+                                                                            {/if}
+                                                                            {else}
+                                                                                {$product.name|escape:'htmlall':'UTF-8'}
+                                                                                {if isset($product.attributes) && $product.attributes}
+                                                                                    {$product.attributes|escape:'htmlall':'UTF-8'}
+                                                                                {/if}
+                                                                                {if !$product@last}
+                                                                                    ,&nbsp;
+                                                                                {else}
+                                                                                    )
+                                                                                {/if}
+                                                                            {/if}
+                                                                                {strip}
+                                                                            {/foreach}
+                                                                        {/if}
+                                                                    </td>
+                                                                    <td rowspan="{$option.carrier_list|@count}" class="delivery_option_price">
+                                                                        <div class="delivery_option_price">
+                                                                            {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                                                                                {if $use_taxes == 1}
+                                                                                    {if $priceDisplay == 1}
+                                                                                        {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
+                                                                                    {else}
+                                                                                        {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                                                                    {/if}
+                                                                                {else}
+                                                                                    {convertPrice price=$option.total_price_without_tax}
+                                                                                {/if}
+                                                                            {else}
+                                                                                {l s='Free'}
+                                                                            {/if}
+                                                                        </div>
+                                                                    </td>
+                                                                </tr>
+                                                                {foreach $option.carrier_list as $carrier}
+                                                                    {if $carrier@iteration != 1}
+                                                                        <tr>
+                                                                            <td class="delivery_option_logo{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                                                                {if $carrier.logo}
+                                                                                    <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                                                                                {elseif !$option.unique_carrier}
+                                                                                    {$carrier.instance->name|escape:'htmlall':'UTF-8'}
+                                                                                {/if}
+                                                                            </td>
+                                                                            <td class="{if $option.unique_carrier} first_item{/if}{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                                                                <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                                                                                {if isset($carrier.instance->delay[$cookie->id_lang])}
+                                                                                    <i class="icon-info-sign"></i>
+                                                                                    {strip}
+                                                                                        {$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                                                                        &nbsp;
+                                                                                        {if count($first.product_list) <= 1}
+                                                                                            ({l s='For this product:'}
+                                                                                        {else}
+                                                                                            ({l s='For these products:'}
+                                                                                        {/if}
+                                                                                    {/strip}
+                                                                                    {foreach $carrier.product_list as $product}
+                                                                                        {if $product@index == 4}
+                                                                                            <acronym title="
+																	{/if}
+																	{strip}
+																		{if $product@index >= 4}
+																			{$product.name|escape:'htmlall':'UTF-8'}
+																			{if isset($product.attributes) && $product.attributes}
+																				{$product.attributes|escape:'htmlall':'UTF-8'}
+																			{/if}
+																			{if !$product@last}
+																				,&nbsp;
+																			{else}
+																				">&hellip;</acronym>)
+                                                                                    {/if}
+                                                                                    {else}
+                                                                                        {$product.name|escape:'htmlall':'UTF-8'}
+                                                                                        {if isset($product.attributes) && $product.attributes}
+                                                                                            {$product.attributes|escape:'htmlall':'UTF-8'}
+                                                                                        {/if}
+                                                                                        {if !$product@last}
+                                                                                            ,&nbsp;
+                                                                                        {else}
+                                                                                            )
+                                                                                        {/if}
+                                                                                    {/if}
+                                                                                        {strip}
+                                                                                    {/foreach}
+                                                                                {/if}
+                                                                            </td>
+                                                                        </tr>
+                                                                    {/if}
+                                                                {/foreach}
+                                                            </table>
+                                                        {/if}
+                                                    </div>
+                                                </div> <!-- end delivery_option -->
+                                            {/foreach}
+                                        </div> <!-- end delivery_options -->
+                                        <div class="hook_extracarrier" id="HOOK_EXTRACARRIER_{$id_address}">
+                                            {if isset($HOOK_EXTRACARRIER_ADDR) &&  isset($HOOK_EXTRACARRIER_ADDR.$id_address)}{$HOOK_EXTRACARRIER_ADDR.$id_address}{/if}
+                                        </div>
+                                        {foreachelse}
+                                        {assign var='errors' value=' '|explode:''}
+                                        <p class="alert alert-warning" id="noCarrierWarning">
+                                            {foreach $cart->getDeliveryAddressesWithoutCarriers(true, $errors) as $address}
+                                                {if empty($address->alias)}
+                                                    {l s='No carriers available.'}
+                                                {else}
+                                                    {assign var='flag_error_message' value=false}
+                                                    {foreach $errors as $error}
+                                                        {if $error == Carrier::SHIPPING_WEIGHT_EXCEPTION}
+                                                            {$flag_error_message = true}
+                                                            {l s='The product selection cannot be delivered by the available carrier(s): it is too heavy. Please amend your cart to lower its weight.'}
+                                                        {elseif $error == Carrier::SHIPPING_PRICE_EXCEPTION}
+                                                            {$flag_error_message = true}
+                                                            {l s='The product selection cannot be delivered by the available carrier(s). Please amend your cart.'}
+                                                        {elseif $error == Carrier::SHIPPING_SIZE_EXCEPTION}
+                                                            {$flag_error_message = true}
+                                                            {l s='The product selection cannot be delivered by the available carrier(s): its size does not fit. Please amend your cart to reduce its size.'}
+                                                        {/if}
+                                                    {/foreach}
+                                                    {if !$flag_error_message}
+                                                        {l s='No carriers available for the address "%s".' sprintf=$address->alias}
+                                                    {/if}
+                                                {/if}
+                                                {if !$address@last}
+                                                    <br />
+                                                {/if}
+                                                {foreachelse}
+                                                {l s='No carriers available.'}
+                                            {/foreach}
+                                        </p>
+                                    {/foreach}
+                                {/if}
+                            </div> <!-- end delivery_options_address -->
+                            <div id="extra_carrier" style="display: none;"></div>
+                            {if $opc}
+                                <p class="carrier_title">{l s='Leave a message'}</p>
+                                <div>
+                                    <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
+						<textarea class="form-control" cols="120" rows="2" name="message" id="message">{strip}
+							{if isset($oldMessage)}{$oldMessage|escape:'html':'UTF-8'}{/if}
+						{/strip}</textarea>
+                                </div>
+                            {/if}
+                            {if $recyclablePackAllowed}
+                                <div class="checkbox recyclable">
+                                    <p class="carrier_title">{l s='Recyclable Packaging'}</p>
+                                    <label for="recyclable">
+                                        <input type="checkbox" name="recyclable" id="recyclable" value="1"{if $recyclable == 1} checked="checked"{/if} />
+                                        {l s='I would like to receive my order in recycled packaging.'}
+                                    </label>
+                                </div>
+                            {/if}
+                            {if $giftAllowed}
+                                {if $opc}
+                                    <hr style="" />
+                                {/if}
+                                <p class="carrier_title">{l s='Gift'}</p>
+                                <p class="checkbox gift">
+                                    <input type="checkbox" name="gift" id="gift" value="1"{if $cart->gift == 1} checked="checked"{/if} />
+                                    <label for="gift">
+                                        {l s='I would like my order to be gift wrapped.'}
+                                        {if $gift_wrapping_price > 0}
+                                            &nbsp;<i>({l s='Additional cost of'}
+                                            <span class="price" id="gift-price">
+									{if $priceDisplay == 1}
+                                        {convertPrice price=$total_wrapping_tax_exc_cost}
+                                    {else}
+                                        {convertPrice price=$total_wrapping_cost}
+                                    {/if}
+								</span>
+                                            {if $use_taxes && $display_tax_label}
+                                                {if $priceDisplay == 1}
+                                                    {l s='(tax excl.)'}
+                                                {else}
+                                                    {l s='(tax incl.)'}
+                                                {/if}
+                                            {/if})
+                                        </i>
+                                        {/if}
+                                    </label>
+                                </p>
+                                <p id="gift_div">
+                                    <label for="gift_message">{l s='If you\'d like, you can add a note to the gift:'}</label>
+                                    <textarea rows="2" cols="120" id="gift_message" class="form-control" name="gift_message">{$cart->gift_message|escape:'html':'UTF-8'}</textarea>
+                                </p>
+                            {/if}
+                        {/if}
+                    {/if}
+                    {if $conditions && $cms_id && !$advanced_payment_api}
+                        {if $opc}
+                            <hr style="" />
+                        {/if}
+                        {if $override_tos_display }
+                            {$override_tos_display}
+                        {else}
+                            <div class="box">
+                                <p class="checkbox">
+                                    <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
+                                    <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
+                                    <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
+                                </p>
+                            </div>
+                        {/if}
+                    {/if}
+                </div> <!-- end delivery_options_address -->
+                {if !$opc}
+                <p class="cart_navigation clearfix">
+                    <input type="hidden" name="step" value="3" />
+                    <input type="hidden" name="back" value="{$back}" />
+                    {if !$is_guest}
+                        {if $back}
+                            <a href="{$link->getPageLink('order', true, NULL, "step=1&back={$back}{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+                                <i class="icon-chevron-left"></i>
+                                {l s='Continue shopping'}
+                            </a>
+                        {else}
+                            <a href="{$link->getPageLink('order', true, NULL, "step=1{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+                                <i class="icon-chevron-left"></i>
+                                {l s='Continue shopping'}
+                            </a>
+                        {/if}
+                    {else}
+                        <a href="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+                            <i class="icon-chevron-left"></i>
+                            {l s='Continue shopping'}
+                        </a>
+                    {/if}
+                    {if isset($virtual_cart) && $virtual_cart || (isset($delivery_option_list) && !empty($delivery_option_list))}
+                        <button type="submit" name="processCarrier" class="button btn btn-default standard-checkout button-medium">
+							<span>
+								{l s='Proceed to checkout'}
+                                <i class="icon-chevron-right right"></i>
+							</span>
+                        </button>
+                    {/if}
+                </p>
+    </form>
+    {else}
+</div>
+{/if}
+</div> <!-- end carrier_area -->
+{strip}
+    {if !$opc}
+        {addJsDef orderProcess='order'}
+        {if isset($virtual_cart) && !$virtual_cart && $giftAllowed && $cart->gift == 1}
+            {addJsDef cart_gift=true}
+        {else}
+            {addJsDef cart_gift=false}
+        {/if}
+        {addJsDef orderUrl=$link->getPageLink("order", true)|escape:'quotes':'UTF-8'}
+        {addJsDefL name=txtProduct}{l s='Product' js=1}{/addJsDefL}
+        {addJsDefL name=txtProducts}{l s='Products' js=1}{/addJsDefL}
+    {/if}
+    {if $conditions}
+        {addJsDefL name=msg_order_carrier}{l s='You must agree to the terms of service before continuing.' js=1}{/addJsDefL}
+    {/if}
+{/strip}

--- a/themes/hotel-reservation-theme/order-carrier-opc-advanced.tpl
+++ b/themes/hotel-reservation-theme/order-carrier-opc-advanced.tpl
@@ -1,1 +1,360 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+<div class="order_carrier_content box">
+    {if isset($virtual_cart) && $virtual_cart}
+        <input id="input_virtual_carrier" class="hidden" type="hidden" name="id_carrier" value="0" />
+    {else}
+        <div id="HOOK_BEFORECARRIER">
+            {if isset($carriers) && isset($HOOK_BEFORECARRIER)}
+                {$HOOK_BEFORECARRIER}
+            {/if}
+        </div>
+        {if isset($isVirtualCart) && $isVirtualCart}
+            <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
+        {else}
+            <div class="delivery_options_address">
+                {if isset($delivery_option_list)}
+                    {foreach $delivery_option_list as $id_address => $option_list}
+                        <p class="carrier_title">
+                            {if isset($address_collection[$id_address])}
+                                {l s='Choose a shipping option for this address:'} {$address_collection[$id_address]->alias}
+                            {else}
+                                {l s='Choose a shipping option'}
+                            {/if}
+                        </p>
+                        <div class="delivery_options">
+                            {foreach $option_list as $key => $option}
+                                <div class="delivery_option {if ($option@index % 2)}alternate_{/if}item">
+                                    <div>
+                                        <table class="resume table table-bordered{if !$option.unique_carrier} hide{/if}">
+                                            <tr>
+                                                <td class="delivery_option_radio">
+                                                    <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                                                </td>
+                                                <td class="delivery_option_logo">
+                                                    {foreach $option.carrier_list as $carrier}
+                                                        {if $carrier.logo}
+                                                            <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                                                        {elseif !$option.unique_carrier}
+                                                            {$carrier.instance->name|escape:'htmlall':'UTF-8'}
+                                                            {if !$carrier@last} - {/if}
+                                                        {/if}
+                                                    {/foreach}
+                                                </td>
+                                                <td>
+                                                    {if $option.unique_carrier}
+                                                        {foreach $option.carrier_list as $carrier}
+                                                            <strong>{$carrier.instance->name|escape:'htmlall':'UTF-8'}</strong>
+                                                        {/foreach}
+                                                        {if isset($carrier.instance->delay[$cookie->id_lang])}
+                                                            <br />{l s='Delivery time:'}&nbsp;{$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                                        {/if}
+                                                    {/if}
+                                                    {if count($option_list) > 1}
+                                                        <br />
+                                                        {if $option.is_best_grade}
+                                                            {if $option.is_best_price}
+                                                                <span class="best_grade best_grade_price best_grade_speed">{l s='The best price and speed'}</span>
+                                                            {else}
+                                                                <span class="best_grade best_grade_speed">{l s='The fastest'}</span>
+                                                            {/if}
+                                                        {elseif $option.is_best_price}
+                                                            <span class="best_grade best_grade_price">{l s='The best price'}</span>
+                                                        {/if}
+                                                    {/if}
+                                                </td>
+                                                <td class="delivery_option_price">
+                                                    <div class="delivery_option_price">
+                                                        {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                                                            {if $use_taxes == 1}
+                                                                {if $priceDisplay == 1}
+                                                                    {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
+                                                                {else}
+                                                                    {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                                                {/if}
+                                                            {else}
+                                                                {convertPrice price=$option.total_price_without_tax}
+                                                            {/if}
+                                                        {else}
+                                                            {l s='Free'}
+                                                        {/if}
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        {if !$option.unique_carrier}
+                                            <table class="delivery_option_carrier{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} selected{/if} resume table table-bordered{if $option.unique_carrier} hide{/if}">
+                                                <tr>
+                                                    {if !$option.unique_carrier}
+                                                        <td rowspan="{$option.carrier_list|@count}" class="delivery_option_radio first_item">
+                                                            <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                                                        </td>
+                                                    {/if}
+                                                    {assign var="first" value=current($option.carrier_list)}
+                                                    <td class="delivery_option_logo{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                                        {if $first.logo}
+                                                            <img class="order_carrier_logo" src="{$first.logo|escape:'htmlall':'UTF-8'}" alt="{$first.instance->name|escape:'htmlall':'UTF-8'}"/>
+                                                        {elseif !$option.unique_carrier}
+                                                            {$first.instance->name|escape:'htmlall':'UTF-8'}
+                                                        {/if}
+                                                    </td>
+                                                    <td class="{if $option.unique_carrier}first_item{/if}{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                                        <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                                                        {if isset($first.instance->delay[$cookie->id_lang])}
+                                                            <i class="icon-info-sign"></i>
+                                                            {strip}
+                                                                {$first.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                                                &nbsp;
+                                                                {if count($first.product_list) <= 1}
+                                                                    ({l s='For this product:'}
+                                                                {else}
+                                                                    ({l s='For these products:'}
+                                                                {/if}
+                                                            {/strip}
+                                                            {foreach $first.product_list as $product}
+                                                                {if $product@index == 4}
+                                                                    <acronym title="
+                                                                {/if}
+                                                                {strip}
+                                                                    {if $product@index >= 4}
+                                                                        {$product.name|escape:'htmlall':'UTF-8'}
+                                                                        {if isset($product.attributes) && $product.attributes}
+                                                                            {$product.attributes|escape:'htmlall':'UTF-8'}
+                                                                        {/if}
+                                                                        {if !$product@last}
+                                                                            ,&nbsp;
+                                                                        {else}
+                                                                            ">&hellip;</acronym>)
+                                                                        {/if}
+                                                                    {else}
+                                                                        {$product.name|escape:'htmlall':'UTF-8'}
+                                                                        {if isset($product.attributes) && $product.attributes}
+                                                                            {$product.attributes|escape:'htmlall':'UTF-8'}
+                                                                        {/if}
+                                                                        {if !$product@last}
+                                                                            ,&nbsp;
+                                                                        {else}
+                                                                            )
+                                                                        {/if}
+                                                                    {/if}
+                                                                {/strip}
+                                                            {/foreach}
+                                                        {/if}
+                                                    </td>
+                                                    <td rowspan="{$option.carrier_list|@count}" class="delivery_option_price">
+                                                        <div class="delivery_option_price">
+                                                            {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                                                                {if $use_taxes == 1}
+                                                                    {if $priceDisplay == 1}
+                                                                        {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
+                                                                    {else}
+                                                                        {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                                                    {/if}
+                                                                {else}
+                                                                    {convertPrice price=$option.total_price_without_tax}
+                                                                {/if}
+                                                            {else}
+                                                                {l s='Free'}
+                                                            {/if}
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                                {foreach $option.carrier_list as $carrier}
+                                                    {if $carrier@iteration != 1}
+                                                        <tr>
+                                                            <td class="delivery_option_logo{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                                                {if $carrier.logo}
+                                                                    <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                                                                {elseif !$option.unique_carrier}
+                                                                    {$carrier.instance->name|escape:'htmlall':'UTF-8'}
+                                                                {/if}
+                                                            </td>
+                                                            <td class="{if $option.unique_carrier} first_item{/if}{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                                                <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                                                                {if isset($carrier.instance->delay[$cookie->id_lang])}
+                                                                    <i class="icon-info-sign"></i>
+                                                                    {strip}
+                                                                        {$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                                                        &nbsp;
+                                                                        {if count($first.product_list) <= 1}
+                                                                            ({l s='For this product:'}
+                                                                        {else}
+                                                                            ({l s='For these products:'}
+                                                                        {/if}
+                                                                    {/strip}
+                                                                    {foreach $carrier.product_list as $product}
+                                                                        {if $product@index == 4}
+                                                                            <acronym title="
+                                                                        {/if}
+                                                                        {strip}
+                                                                            {if $product@index >= 4}
+                                                                                {$product.name|escape:'htmlall':'UTF-8'}
+                                                                                {if isset($product.attributes) && $product.attributes}
+                                                                                    {$product.attributes|escape:'htmlall':'UTF-8'}
+                                                                                {/if}
+                                                                                {if !$product@last}
+                                                                                    ,&nbsp;
+                                                                                {else}
+                                                                                    ">&hellip;</acronym>)
+                                                                                {/if}
+                                                                            {else}
+                                                                                {$product.name|escape:'htmlall':'UTF-8'}
+                                                                                {if isset($product.attributes) && $product.attributes}
+                                                                                    {$product.attributes|escape:'htmlall':'UTF-8'}
+                                                                                {/if}
+                                                                                {if !$product@last}
+                                                                                    ,&nbsp;
+                                                                                {else}
+                                                                                    )
+                                                                                {/if}
+                                                                            {/if}
+                                                                        {/strip}
+                                                                    {/foreach}
+                                                                {/if}
+                                                            </td>
+                                                        </tr>
+                                                    {/if}
+                                                {/foreach}
+                                            </table>
+                                        {/if}
+                                    </div>
+                                </div> <!-- end delivery_option -->
+                            {/foreach}
+                        </div> <!-- end delivery_options -->
+                        <div class="hook_extracarrier" id="HOOK_EXTRACARRIER_{$id_address}">
+                            {if isset($HOOK_EXTRACARRIER_ADDR) &&  isset($HOOK_EXTRACARRIER_ADDR.$id_address)}{$HOOK_EXTRACARRIER_ADDR.$id_address}{/if}
+                        </div>
+                        {foreachelse}
+                        {assign var='errors' value=' '|explode:''}
+                        <p class="alert alert-warning" id="noCarrierWarning">
+                            {foreach $cart->getDeliveryAddressesWithoutCarriers(true, $errors) as $address}
+                                {if empty($address->alias)}
+                                    {l s='No carriers available.'}
+                                {else}
+                                    {assign var='flag_error_message' value=false}
+                                    {foreach $errors as $error}
+                                        {if $error == Carrier::SHIPPING_WEIGHT_EXCEPTION}
+                                            {$flag_error_message = true}
+                                            {l s='The product selection cannot be delivered by the available carrier(s): it is too heavy. Please amend your cart to lower its weight.'}
+                                        {elseif $error == Carrier::SHIPPING_PRICE_EXCEPTION}
+                                            {$flag_error_message = true}
+                                            {l s='The product selection cannot be delivered by the available carrier(s). Please amend your cart.'}
+                                        {elseif $error == Carrier::SHIPPING_SIZE_EXCEPTION}
+                                            {$flag_error_message = true}
+                                            {l s='The product selection cannot be delivered by the available carrier(s): its size does not fit. Please amend your cart to reduce its size.'}
+                                        {/if}
+                                    {/foreach}
+                                    {if !$flag_error_message}
+                                        {l s='No carriers available for the address "%s".' sprintf=$address->alias}
+                                    {/if}
+                                {/if}
+                                {if !$address@last}
+                                    <br />
+                                {/if}
+                                {foreachelse}
+                                {l s='No carriers available.'}
+                            {/foreach}
+                        </p>
+                    {/foreach}
+                {/if}
+            </div> <!-- end delivery_options_address -->
+            <div id="extra_carrier" style="display: none;"></div>
+            {if $opc}
+                <p class="carrier_title">{l s='Leave a message'}</p>
+                <div>
+                    <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
+        <textarea class="form-control" cols="120" rows="2" name="message" id="message">{strip}
+            {if isset($oldMessage)}{$oldMessage|escape:'html':'UTF-8'}{/if}
+        {/strip}</textarea>
+                </div>
+            {/if}
+            {if $recyclablePackAllowed}
+                <p class="carrier_title">{l s='Recyclable Packaging'}</p>
+                <div class="checkbox recyclable">
+                    <label for="recyclable">
+                        <input type="checkbox" name="recyclable" id="recyclable" value="1"{if $recyclable == 1} checked="checked"{/if} />
+                        {l s='I would like to receive my order in recycled packaging.'}
+                    </label>
+                </div>
+            {/if}
+            {if $giftAllowed}
+                {if $opc}
+                    <hr style="" />
+                {/if}
+                <p class="carrier_title">{l s='Gift'}</p>
+                <p class="checkbox gift">
+                    <input type="checkbox" name="gift" id="gift" value="1"{if $cart->gift == 1} checked="checked"{/if} />
+                    <label for="gift">
+                        {l s='I would like my order to be gift wrapped.'}
+                        {if $gift_wrapping_price > 0}
+                            &nbsp;<i>({l s='Additional cost of'}
+                            <span class="price" id="gift-price">
+                    {if $priceDisplay == 1}
+                        {convertPrice price=$total_wrapping_tax_exc_cost}
+                    {else}
+                        {convertPrice price=$total_wrapping_cost}
+                    {/if}
+                </span>
+                            {if $use_taxes && $display_tax_label}
+                                {if $priceDisplay == 1}
+                                    {l s='(tax excl.)'}
+                                {else}
+                                    {l s='(tax incl.)'}
+                                {/if}
+                            {/if})
+                        </i>
+                        {/if}
+                    </label>
+                </p>
+                <p id="gift_div">
+                    <label for="gift_message">{l s='If you\'d like, you can add a note to the gift:'}</label>
+                    <textarea rows="2" cols="120" id="gift_message" class="form-control" name="gift_message">{$cart->gift_message|escape:'html':'UTF-8'}</textarea>
+                </p>
+            {/if}
+        {/if}
+    {/if}
+    {if $conditions && $cms_id && !$advanced_payment_api}
+        {if $opc}
+            <hr style="" />
+        {/if}
+        {if $override_tos_display }
+            {$override_tos_display}
+        {else}
+            <div class="box">
+                <p class="checkbox">
+                    <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
+                    <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
+                    <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
+                </p>
+            </div>
+        {/if}
+    {/if}
+</div> <!-- end delivery_options_address -->
+</div> <!-- end carrier_area -->
+{strip}
+    {if $conditions}
+        {addJsDefL name=msg_order_carrier}{l s='You must agree to the terms of service before continuing.' js=1}{/addJsDefL}
+    {/if}
+{/strip}

--- a/themes/hotel-reservation-theme/order-carrier.tpl
+++ b/themes/hotel-reservation-theme/order-carrier.tpl
@@ -1,1 +1,32 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+<div class="box" id="tc_cont">
+    <p class="checkbox">
+        <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
+        <label for="cgv" id="tc_txt">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
+        <a id="tc_link" href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow" >{l s='(Read the Terms of Service)'}</a>
+    </p>
+</div>

--- a/themes/hotel-reservation-theme/order-opc-advanced-payment-option.tpl
+++ b/themes/hotel-reservation-theme/order-opc-advanced-payment-option.tpl
@@ -1,1 +1,49 @@
-{extends file='checkout-inquiry.tpl'}
+
+{if isset($advance_payment_active)}
+	<div class="opc_advance_payment_block">
+		<p class="block-small-header">{l s='PAYMENT TYPES'}</p>
+		<div class="row adv_payment_type_form">
+		{block name='order_opc_advanced_payment_option_form'}
+				<form method="POST" action="{$link->getPageLink('order-opc')|escape:'html':'UTF-8'}" id="advanced-payment">
+					<div class="col-sm-12 col-xs-12">
+						<label>
+							<input type="radio" value="1" name="payment_type" class="payment_type" {if !isset($is_advance_payment)}checked="checked"{/if}>
+							<span>{l s='Full Payment'}</span>
+						</label>
+					</div>
+					<div class="col-sm-12 col-xs-12">
+						<label>
+							<input type="radio" value="2" name="payment_type" class="payment_type" {if isset($is_advance_payment)}checked="checked"{/if}>
+							<span>{l s='Partial Payment'}</span>
+						</label>
+
+						<div class="row" id="partial_data">
+							<div class="row margin-lr-0">
+								<div class="col-xs-12 partial_subcont">
+									<span class="partial_txt">{l s='Advance Payment Amount'} - </span>
+									<span class="partial_min_cost">{displayPrice price=$advPaymentAmount}</span>
+								</div>
+							</div>
+
+							{if isset($is_advance_payment)}
+								<div class="row margin-lr-0">
+									<div class="col-xs-12 partial_subcont">
+										<span class="partial_txt">{l s='Due Amount'} - </span>
+										<span class="partial_min_cost">{displayPrice price=$dueAmount}</span>
+									</div>
+								</div>
+							{/if}
+						</div>
+					</div>
+					<div class="col-sm-12 col-xs-12 margin-top-10">
+						{block name='order_opc_advanced_payment_option_submit'}
+							<button class="opc-button-small opc-btn-primary" name="submitAdvPayment" type="submit">
+								<span>{l s='OK'}</span>
+							</button>
+						{/block}
+					</div>
+				</form>
+			{/block}
+		</div>
+	</div>
+{/if}

--- a/themes/hotel-reservation-theme/order-opc-advanced.tpl
+++ b/themes/hotel-reservation-theme/order-opc-advanced.tpl
@@ -1,1 +1,105 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{block name='order_opc_advanced'}
+    {if $opc}
+        {assign var="back_order_page" value="order-opc.php"}
+    {else}
+        {assign var="back_order_page" value="order.php"}
+    {/if}
+
+    {if $PS_CATALOG_MODE}
+        {capture name=path}{l s='Your shopping cart'}{/capture}
+        <h2 id="cart_title">{l s='Your shopping cart'}</h2>
+        <p class="alert alert-warning">{l s='Your new order was not accepted.'}</p>
+    {else}
+        {if $productNumber}
+            <!-- Payment -->
+            {block name='order_payment_advanced'}
+                {include file="$tpl_dir./order-payment-advanced.tpl"}
+            {/block}
+            <!-- END Payment -->
+        {else}
+            {capture name=path}{l s='Your shopping cart'}{/capture}
+            <h2 class="page-heading">{l s='Your shopping cart'}</h2>
+            {block name='errors'}
+                {include file="$tpl_dir./errors.tpl"}
+            {/block}
+            <p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
+        {/if}
+        {block name='order_opc_advanced_js_vars'}
+            {strip}
+                {addJsDef imgDir=$img_dir}
+                {addJsDef authenticationUrl=$link->getPageLink("authentication", true)|escape:'quotes':'UTF-8'}
+                {addJsDef orderOpcUrl=$link->getPageLink("order-opc", true)|escape:'quotes':'UTF-8'}
+                {addJsDef historyUrl=$link->getPageLink("history", true)|escape:'quotes':'UTF-8'}
+                {addJsDef guestTrackingUrl=$link->getPageLink("guest-tracking", true)|escape:'quotes':'UTF-8'}
+                {addJsDef addressUrl=$link->getPageLink("address", true, NULL, "back={$back_order_page}")|escape:'quotes':'UTF-8'}
+                {addJsDef orderProcess='order-opc'}
+                {addJsDef guestCheckoutEnabled=$PS_GUEST_CHECKOUT_ENABLED|intval}
+                {addJsDef displayPrice=$priceDisplay}
+                {addJsDef taxEnabled=$use_taxes}
+                {addJsDef conditionEnabled=$conditions|intval}
+                {addJsDef errorCarrier=$errorCarrier|@addcslashes:'\''}
+                {addJsDef errorTOS=$errorTOS|@addcslashes:'\''}
+                {addJsDef checkedCarrier=$checked|intval}
+                {addJsDef addresses=array()}
+                {addJsDef isVirtualCart=$isVirtualCart|intval}
+                {addJsDef isPaymentStep=$isPaymentStep|intval}
+                {addJsDefL name=txtWithTax}{l s='(tax incl.)' js=1}{/addJsDefL}
+                {addJsDefL name=txtWithoutTax}{l s='(tax excl.)' js=1}{/addJsDefL}
+                {addJsDefL name=txtHasBeenSelected}{l s='has been selected' js=1}{/addJsDefL}
+                {addJsDefL name=txtNoCarrierIsSelected}{l s='No carrier has been selected' js=1}{/addJsDefL}
+                {addJsDefL name=txtNoCarrierIsNeeded}{l s='No carrier is needed for this order' js=1}{/addJsDefL}
+                {addJsDefL name=txtConditionsIsNotNeeded}{l s='You do not need to accept the Terms of Service for this order.' js=1}{/addJsDefL}
+                {addJsDefL name=txtTOSIsAccepted}{l s='The service terms have been accepted' js=1}{/addJsDefL}
+                {addJsDefL name=txtTOSIsNotAccepted}{l s='The service terms have not been accepted' js=1}{/addJsDefL}
+                {addJsDefL name=txtThereis}{l s='There is' js=1}{/addJsDefL}
+                {addJsDefL name=txtErrors}{l s='Error(s)' js=1}{/addJsDefL}
+                {addJsDefL name=txtDeliveryAddress}{l s='Delivery address' js=1}{/addJsDefL}
+                {addJsDefL name=txtInvoiceAddress}{l s='Invoice address' js=1}{/addJsDefL}
+                {addJsDefL name=txtModifyMyAddress}{l s='Modify my address' js=1}{/addJsDefL}
+                {addJsDefL name=txtInstantCheckout}{l s='Instant checkout' js=1}{/addJsDefL}
+                {addJsDefL name=txtSelectAnAddressFirst}{l s='Please start by selecting an address.' js=1}{/addJsDefL}
+                {addJsDefL name=txtFree}{l s='Free' js=1}{/addJsDefL}
+
+                {capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
+                {capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
+                {addJsDef addressUrl=$smarty.capture.addressUrl}
+                {capture}{'&multi-shipping=1'|urlencode}{/capture}
+                {addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
+                {capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
+                {addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
+                {addJsDef opc=$opc|boolval}
+                {capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
+                {addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+                {capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
+                {addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+                {capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
+                {addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+            {/strip}
+        {/block}
+    {/if}
+{/block}

--- a/themes/hotel-reservation-theme/order-opc-edit-guest-info.tpl
+++ b/themes/hotel-reservation-theme/order-opc-edit-guest-info.tpl
@@ -1,1 +1,333 @@
-{extends file='checkout-inquiry.tpl'}
+{**
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License version 3.0
+* that is bundled with this package in the file LICENSE.md
+* It is also available through the world-wide-web at this URL:
+* https://opensource.org/license/osl-3-0-php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to support@qloapps.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade this module to a newer
+* versions in the future. If you wish to customize this module for your needs
+* please refer to https://store.webkul.com/customisation-guidelines for more information.
+*
+* @author Webkul IN
+* @copyright Since 2010 Webkul
+* @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+*}
+
+<div id="opc_new_account" class="opc-main-block">
+    <div id="opc_new_account-overlay" class="opc-overlay" style="display: none;"></div>
+    {block name='order_opc_edit_guest_info_login_form'}
+        <form action="{$link->getPageLink('authentication', true, NULL, "back=order-opc")|escape:'html':'UTF-8'}" method="post" id="login_form">
+            <fieldset>
+                <div id="login_form_content" style="display:none;">
+                    <!-- Error return block -->
+                    <div id="opc_login_errors" class="alert alert-danger" style="display:none;"></div>
+                    <!-- END Error return block -->
+                    <p class="form-group">
+                        <label for="login_email">{l s='Email address'}</label>
+                        <input type="email" class="form-control validate" id="login_email" name="email" data-validate="isEmail" />
+                    </p>
+                    <p class="form-group">
+                        <label for="login_passwd">{l s='Password'}</label>
+                        <input class="form-control validate" type="password" id="login_passwd" name="login_passwd" data-validate="isPasswd" />
+                    </p>
+                    <a href="{$link->getPageLink('password', true)|escape:'html':'UTF-8'}" class="lost_password pull-right">{l s='Forgot your password?'}</a>
+                    <div style="clear:both"></div>
+                    {block name='order_opc_edit_guest_info_login_submit'}
+                        <p class="submit">
+                            {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
+                            <button type="submit" id="SubmitLogin" name="SubmitLogin" class="button btn btn-default button-medium pull-right"><span><i class="icon-lock left"></i>{l s='Sign in'}</span></button>
+                        </p>
+                    {/block}
+                </div>
+            </fieldset>
+        </form>
+    {/block}
+    {block name='order_opc_edit_guest_info_new_account_form'}
+        <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="new_account_form" class="std" autocomplete="on" autofill="on">
+            <div id="opc_account_form" class="unvisible">
+                {block name='displayCustomerAccountFormTop'}
+                    {$HOOK_CREATE_ACCOUNT_TOP}
+                {/block}
+                <div style="display: none;" id="opc_account_saved" class="alert alert-success">
+                    {l s='Account information saved successfully.'}
+                </div>
+                <!-- Error return block -->
+                <div id="opc_account_errors" class="alert alert-danger" style="display:none;"></div>
+                <!-- END Error return block -->
+                <!-- Account -->
+                <input type="hidden" id="is_new_customer" name="is_new_customer" value="0" />
+                <input type="hidden" id="opc_id_customer" name="opc_id_customer" value="{if isset($guestInformations) && isset($guestInformations.id_customer) && $guestInformations.id_customer}{$guestInformations.id_customer}{else}0{/if}" />
+                <input type="hidden" id="opc_id_address_delivery" name="opc_id_address_delivery" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+                <input type="hidden" id="opc_id_address_invoice" name="opc_id_address_invoice" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+                <p class="required"><sup>*</sup>{l s='Required field'}</p>
+
+                <div class="row">
+                    <div class="required clearfix gender-line col-sm-2">
+                        <label>{l s='Social title'}</label>
+                        <select name="id_gender" id="id_gender">
+                            {foreach from=$genders key=k item=gender}
+                                <option value="{$gender->id_gender}"{if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id_gender || (isset($guestInformations) && $guestInformations.id_gender == $gender->id_gender)} selected="selected"{/if}>{$gender->name}</option>
+                            {/foreach}
+                        </select>
+                    </div>
+                    <div class="required form-group col-sm-5">
+                        <label for="firstname">{l s='First name'} <sup>*</sup></label>
+                        <input type="text" class="text form-control validate" id="customer_firstname" name="customer_firstname" onblur="$('#firstname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_firstname) && $guestInformations.customer_firstname}{$guestInformations.customer_firstname}{/if}" />
+                    </div>
+                    <div class="required form-group col-sm-5">
+                        <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+                        <input type="text" class="form-control validate" id="customer_lastname" name="customer_lastname" onblur="$('#lastname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_lastname) && $guestInformations.customer_lastname}{$guestInformations.customer_lastname}{/if}" />
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="required text form-group col-sm-6">
+                        <label for="email">{l s='Email'} <sup>*</sup></label>
+                        <input type="email" class="text form-control validate" id="email" name="email" data-validate="isEmail" value="{if isset($guestInformations) && isset($guestInformations.email) && $guestInformations.email}{$guestInformations.email}{/if}" />
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group col-sm-6">
+                        <label for="phone">{l s='Phone Number'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+                        <input type="text" class="text form-control validate" name="phone" id="phone" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone) && $guestInformations.phone}{$guestInformations.phone}{/if}" />
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="transform-to-customer-block">
+                            <p class="strikethrough"><span>{l s='OR'}</span></p>
+                            <p class="text-secondary">{l s='Create a customer account using above details.'}</p>
+                            <div class="row">
+                                <div class="required password form-group col-sm-12">
+                                    <label for="passwd">{l s='Password'} <sup>*</sup></label>
+                                    <input type="password" class="text form-control validate" name="passwd" id="passwd" data-validate="isPasswd" />
+                                    <span class="form_info">{l s='(five characters min.)'}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {if isset($PS_REGISTRATION_PROCESS_TYPE) && $PS_REGISTRATION_PROCESS_TYPE}
+                    <div class="row">
+                        <div class="select form-group date-select col-sm-12">
+                            <label>{l s='Date of Birth'}</label>
+                            <div class="row">
+                                <div class="col-xs-4">
+                                    <select id="days" name="days">
+                                        <option value="">-</option>
+                                        {foreach from=$days item=day}
+                                        <option value="{$day|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_day) && ($guestInformations.sl_day == $day)} selected="selected"{/if}>{$day|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+                                        {/foreach}
+                                    </select>
+                                </div>
+                                <div class="col-xs-4">
+                                    <select id="months" name="months">
+                                        <option value="">-</option>
+                                        {foreach from=$months key=k item=month}
+                                        <option value="{$k|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_month) && ($guestInformations.sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
+                                        {/foreach}
+                                    </select>
+                                </div>
+                                <div class="col-xs-4">
+                                    <select id="years" name="years">
+                                        <option value="">-</option>
+                                        {foreach from=$years item=year}
+                                        <option value="{$year|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_year) && ($guestInformations.sl_year == $year)} selected="selected"{/if}>{$year|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+                                        {/foreach}
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {if isset($newsletter) && $newsletter}
+                        <div class="checkbox">
+                            <label for="newsletter">
+                            <input type="checkbox" name="newsletter" id="newsletter" value="1"{if isset($guestInformations) && isset($guestInformations.newsletter) && $guestInformations.newsletter} checked="checked"{/if} autocomplete="off"/>
+                            {l s='Sign up for our newsletter!'}</label>
+                            {if array_key_exists('newsletter', $field_required)}
+                                <sup> *</sup>
+                            {/if}
+                        </div>
+                    {/if}
+                    {if isset($optin) && $optin}
+                        <div class="checkbox">
+                            <label for="optin">
+                            <input type="checkbox" name="optin" id="optin" value="1"{if isset($guestInformations) && isset($guestInformations.optin) && $guestInformations.optin} checked="checked"{/if} autocomplete="off"/>
+                            {l s='Receive special offers from our partners!'}</label>
+                            {if array_key_exists('optin', $field_required)}
+                                <sup> *</sup>
+                            {/if}
+                        </div>
+                    {/if}
+
+                    <p class="block-small-header margin-top-20 margin-btm-10">{l s='RESIDENTIAL ADDRESS'}</p>
+                    {$stateExist = false}
+                    {$postCodeExist = false}
+                    {$dniExist = false}
+                    <div class="row">
+                        {foreach from=$dlv_all_fields item=field_name}
+                            {if $field_name eq "firstname"}
+                                <div class="required text form-group col-sm-6">
+                                    <label for="firstname">{l s='First name'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" id="firstname" name="firstname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname) && $guestInformations.firstname}{$guestInformations.firstname}{/if}" />
+                                </div>
+                            {elseif $field_name eq "lastname"}
+                                <div class="required text form-group col-sm-6">
+                                    <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" id="lastname" name="lastname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname) && $guestInformations.lastname}{$guestInformations.lastname}{/if}" />
+                                </div>
+                            {elseif $field_name eq "address1"}
+                                <div class="required text form-group col-sm-6">
+                                    <label for="address1">{l s='Address'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" name="address1" id="address1" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1) && isset($guestInformations) && isset($guestInformations.address1) && $guestInformations.address1}{$guestInformations.address1}{/if}" />
+                                </div>
+                            {elseif $field_name eq "address2"}
+                                <div class="text{if !in_array($field_name, $required_fields)} is_customer_param{/if} form-group col-sm-6">
+                                    <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                                    <input type="text" class="text form-control validate" name="address2" id="address2" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2) && isset($guestInformations) && isset($guestInformations.address2) && $guestInformations.address2}{$guestInformations.address2}{/if}" />
+                                </div>
+                            {elseif $field_name eq "city"}
+                                <div class="required text form-group col-sm-6">
+                                    <label for="city">{l s='City'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" name="city" id="city" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city) && $guestInformations.city}{$guestInformations.city}{/if}" />
+                                </div>
+                            {elseif $field_name eq "postcode"}
+                                {$postCodeExist = true}
+                                <div class="required postcode text form-group col-sm-6">
+                                    <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+                                </div>
+                            {elseif $field_name eq "company"}
+                                <div class="text form-group col-sm-6">
+                                    <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                                    <input type="text" class="text form-control validate" id="company" name="company" data-validate="isGenericName" value="{if isset($guestInformations) && isset($guestInformations.company) && $guestInformations.company}{$guestInformations.company}{/if}" />
+                                </div>
+                            {elseif $field_name eq "vat_number"}
+                                <div id="vat_number_block" style="display:none;">
+                                    <div class="form-group col-sm-6">
+                                        <label for="vat_number">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                                        <input type="text" class="text form-control" name="vat_number" id="vat_number" value="{if isset($guestInformations) && isset($guestInformations.vat_number) && $guestInformations.vat_number}{$guestInformations.vat_number}{/if}" />
+                                    </div>
+                                </div>
+                            {elseif $field_name eq "dni"}
+                                {assign var='dniExist' value=true}
+                                <div class="required dni form-group col-sm-6">
+                                    <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+                                    <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+                                </div>
+                            {elseif $field_name eq "country" || $field_name eq "Country:name"}
+                                <div class="required select form-group col-sm-6">
+                                    <label for="id_country">{l s='Country'} <sup>*</sup></label>
+                                    <select name="id_country" id="id_country">
+                                        {foreach from=$countries item=v}
+                                        <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
+                                        {/foreach}
+                                    </select>
+                                </div>
+                            {elseif $field_name eq "state" || $field_name eq 'State:name'}
+                                {$stateExist = true}
+                                <div class="required id_state form-group col-sm-6" style="display:none;">
+                                    <label for="id_state">{l s='State'} <sup>*</sup></label>
+                                    <select name="id_state" id="id_state">
+                                        <option value="">-</option>
+                                    </select>
+                                </div>
+                            {/if}
+                        {/foreach}
+                        {if !$postCodeExist}
+                            <div class="required postcode form-group col-sm-6 unvisible">
+                                <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+                                <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+                            </div>
+                        {/if}
+                        {if !$stateExist}
+                            <div class="required id_state form-group col-sm-6 unvisible">
+                                <label for="id_state">{l s='State'} <sup>*</sup></label>
+                                <select name="id_state" id="id_state">
+                                    <option value="">-</option>
+                                </select>
+                            </div>
+                        {/if}
+                        {if !$dniExist}
+                            <div class="required dni form-group col-sm-6">
+                                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                                <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+                                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+                            </div>
+                        {/if}
+                        <div class="form-group is_customer_param col-sm-6">
+                            <label for="phone">{l s='Home phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+                            <input type="text" class="text form-control validate" name="phone" id="phone" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone) && $guestInformations.phone}{$guestInformations.phone}{/if}" />
+                        </div>
+                        <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group col-sm-6">
+                            <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+                            <input type="text" class="text form-control validate" name="phone_mobile" id="phone_mobile" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile) && $guestInformations.phone_mobile}{$guestInformations.phone_mobile}{/if}" />
+                        </div>
+                        <div class="form-group is_customer_param col-sm-6">
+                            <label for="other">{l s='Additional information'}</label>
+                            <textarea class="form-control" name="other" id="other" cols="26" rows="7"></textarea>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-12">
+                            {if isset($one_phone_at_least) && $one_phone_at_least}
+                                {assign var="atLeastOneExists" value=true}
+                                <p class="inline-infos required">** {l s='You must register at least one phone number.'}</p>
+                            {/if}
+                            <input type="hidden" name="alias" id="alias" value="{l s='My address'}"/>
+
+                            <p class="required opc-required">
+                                <sup>*</sup>{l s='Required field'}
+                            </p>
+                        </div>
+                    </div>
+                {/if}
+                {block name='displayCustomerAccountForm'}
+                    {$HOOK_CREATE_ACCOUNT_FORM}
+                {/block}
+                {block name='order_opc_edit_guest_info_account_submit'}
+                    <div class="submit opc-add-save clearfix">
+                        <button type="submit" name="submitAccount" id="submitAccount" class="btn btn-default button button-medium pull-right"><span>{l s='Save'}<i class="icon-chevron-right right"></i></span></button>
+                    </div>
+                {/block}
+            <!-- END Account -->
+            </div>
+        </form>
+    {/block}
+</div>
+
+{block name='order_opc_edit_guest_info_js_vars'}
+    {strip}
+        {if isset($guestInformations) && isset($guestInformations.id_state) && $guestInformations.id_state}
+            {addJsDef idSelectedState=$guestInformations.id_state|intval}
+        {else}
+            {addJsDef idSelectedState=false}
+        {/if}
+        {if isset($guestInformations) && isset($guestInformations.id_state_invoice) && $guestInformations.id_state_invoice}
+            {addJsDef idSelectedStateInvoice=$guestInformations.id_state_invoice|intval}
+        {else}
+            {addJsDef idSelectedStateInvoice=false}
+        {/if}
+        {if isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country}
+            {addJsDef idSelectedCountry=$guestInformations.id_country|intval}
+        {else}
+            {addJsDef idSelectedCountry=false}
+        {/if}
+        {if isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice}
+            {addJsDef idSelectedCountryInvoice=$guestInformations.id_country_invoice|intval}
+        {else}
+            {addJsDef idSelectedCountryInvoice=false}
+        {/if}
+    {/strip}
+{/block}

--- a/themes/hotel-reservation-theme/order-opc-new-account-advanced.tpl
+++ b/themes/hotel-reservation-theme/order-opc-new-account-advanced.tpl
@@ -1,1 +1,422 @@
-{extends file='checkout-inquiry.tpl'}
+<div id="opc_new_account" class="opc-main-block">
+    <div id="opc_new_account-overlay" class="opc-overlay" style="display: none;"></div>
+    <h2>{l s='Account'}</h2>
+    {block name='order_opc_new_account_advanced_login_form'}
+        <form action="{$link->getPageLink('authentication', true, NULL, "back=order-opc")|escape:'html':'UTF-8'}" method="post" id="login_form" class="box">
+            <fieldset>
+                <h3 class="page-subheading">{l s='Already registered?'}</h3>
+                <p><a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" id="openLoginFormBlock">&raquo; {l s='Click here'}</a></p>
+                <div id="login_form_content" style="display:none;">
+                    <!-- Error return block -->
+                    <div id="opc_login_errors" class="alert alert-danger" style="display:none;"></div>
+                    <!-- END Error return block -->
+                    <p class="form-group">
+                        <label for="login_email">{l s='Email address'}</label>
+                        <input type="email" class="form-control validate" id="login_email" name="email" data-validate="isEmail" />
+                    </p>
+                    <p class="form-group">
+                        <label for="login_passwd">{l s='Password'}</label>
+                        <input class="form-control validate" type="password" id="login_passwd" name="login_passwd" data-validate="isPasswd" />
+                    </p>
+                    <a href="{$link->getPageLink('password', true)|escape:'html':'UTF-8'}" class="lost_password">{l s='Forgot your password?'}</a>
+                    {block name='order_opc_new_account_advanced_login_submit'}
+                        <p class="submit">
+                            {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
+                            <button type="submit" id="SubmitLogin" name="SubmitLogin" data-adv-api="1" class="button btn btn-default button-medium"><span><i class="icon-lock left"></i>{l s='Sign in'}</span></button>
+                        </p>
+                    {/block}
+                </div>
+            </fieldset>
+        </form>
+    {/block}
+    {block name='order_opc_new_account_advanced_new_account_form'}
+        <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="new_account_form" class="std" autocomplete="on" autofill="on">
+            <fieldset>
+                <div class="box">
+                    <h3 id="new_account_title" class="page-subheading">{l s='New Customer'}</h3>
+                    <div id="opc_account_choice" class="row">
+                        <div class="col-xs-12 col-md-6">
+                            <p class="title_block">{l s='Instant Checkout'}</p>
+                            <p class="opc-button">
+                                <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_guestCheckout"><span>{l s='Guest checkout'}</span></button>
+                            </p>
+                        </div>
+                        <div class="col-xs-12 col-md-6">
+                            <p class="title_block">{l s='Create your account today and enjoy:'}</p>
+                            <ul class="bullet">
+                                <li>- {l s='Personalized and secure access'}</li>
+                                <li>- {l s='A fast and easy check out process'}</li>
+                                <li>- {l s='Separate billing and shipping addresses'}</li>
+                            </ul>
+                            <p class="opc-button">
+                                <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_createAccount"><span><i class="icon-user left"></i>{l s='Create an account'}</span></button>
+                            </p>
+                        </div>
+                    </div>
+                    <div id="opc_account_form" class="unvisible">
+                        {block name='displayCustomerAccountFormTop'}
+                            {$HOOK_CREATE_ACCOUNT_TOP}
+                        {/block}
+                        <!-- Error return block -->
+                        <div id="opc_account_errors" class="alert alert-danger" style="display:none;"></div>
+                        <!-- END Error return block -->
+                        <!-- Account -->
+                        <input type="hidden" id="is_new_customer" name="is_new_customer" value="0" />
+                        <input type="hidden" id="opc_id_customer" name="opc_id_customer" value="{if isset($guestInformations) && isset($guestInformations.id_customer) && $guestInformations.id_customer}{$guestInformations.id_customer}{else}0{/if}" />
+                        <input type="hidden" id="opc_id_address_delivery" name="opc_id_address_delivery" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+                        <input type="hidden" id="opc_id_address_invoice" name="opc_id_address_invoice" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+                        <div class="required text form-group">
+                            <label for="email">{l s='Email'} <sup>*</sup></label>
+                            <input type="email" class="text form-control validate" id="email" name="email" data-validate="isEmail" value="{if isset($guestInformations) && isset($guestInformations.email) && $guestInformations.email}{$guestInformations.email}{/if}" />
+                        </div>
+                        <div class="required password is_customer_param form-group">
+                            <label for="passwd">{l s='Password'} <sup>*</sup></label>
+                            <input type="password" class="text form-control validate" name="passwd" id="passwd" data-validate="isPasswd" />
+                            <span class="form_info">{l s='(five characters min.)'}</span>
+                        </div>
+                        <div class="required clearfix gender-line">
+                            <label>{l s='Social title'}</label>
+                            {foreach from=$genders key=k item=gender}
+                                <div class="radio-inline">
+                                    <label for="id_gender{$gender->id_gender}" class="top">
+                                        <input type="radio" name="id_gender" id="id_gender{$gender->id_gender}" value="{$gender->id_gender}"{if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id_gender || (isset($guestInformations) && $guestInformations.id_gender == $gender->id_gender)} checked="checked"{/if} />
+                                        {$gender->name}</label></div>
+                            {/foreach}
+                        </div>
+                        <div class="required form-group">
+                            <label for="firstname">{l s='First name'} <sup>*</sup></label>
+                            <input type="text" class="text form-control validate" id="customer_firstname" name="customer_firstname" onblur="$('#firstname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_firstname) && $guestInformations.customer_firstname}{$guestInformations.customer_firstname}{/if}" />
+                        </div>
+                        <div class="required form-group">
+                            <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+                            <input type="text" class="form-control validate" id="customer_lastname" name="customer_lastname" onblur="$('#lastname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_lastname) && $guestInformations.customer_lastname}{$guestInformations.customer_lastname}{/if}" />
+                        </div>
+                        <div class="select form-group date-select">
+                            <label>{l s='Date of Birth'}</label>
+                            <div class="row">
+                                <div class="col-xs-4">
+                                    <select id="days" name="days" class="form-control">
+                                        <option value="">-</option>
+                                        {foreach from=$days item=day}
+                                            <option value="{$day|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_day) && ($guestInformations.sl_day == $day)} selected="selected"{/if}>{$day|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+                                        {/foreach}
+                                    </select>
+                                    {*
+                                    {l s='January'}
+                                    {l s='February'}
+                                    {l s='March'}
+                                    {l s='April'}
+                                    {l s='May'}
+                                    {l s='June'}
+                                    {l s='July'}
+                                    {l s='August'}
+                                    {l s='September'}
+                                    {l s='October'}
+                                    {l s='November'}
+                                    {l s='December'}
+                                    *}
+                                </div>
+                                <div class="col-xs-4">
+                                    <select id="months" name="months" class="form-control">
+                                        <option value="">-</option>
+                                        {foreach from=$months key=k item=month}
+                                            <option value="{$k|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_month) && ($guestInformations.sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
+                                        {/foreach}
+                                    </select>
+                                </div>
+                                <div class="col-xs-4">
+                                    <select id="years" name="years" class="form-control">
+                                        <option value="">-</option>
+                                        {foreach from=$years item=year}
+                                            <option value="{$year|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_year) && ($guestInformations.sl_year == $year)} selected="selected"{/if}>{$year|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+                                        {/foreach}
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        {if isset($newsletter) && $newsletter}
+                            <div class="checkbox">
+                                <label for="newsletter">
+                                    <input type="checkbox" name="newsletter" id="newsletter" value="1"{if isset($guestInformations) && isset($guestInformations.newsletter) && $guestInformations.newsletter} checked="checked"{/if} autocomplete="off"/>
+                                    {l s='Sign up for our newsletter!'}</label>
+                                {if array_key_exists('newsletter', $field_required)}
+                                    <sup> *</sup>
+                                {/if}
+                            </div>
+                        {/if}
+                        {if isset($optin) && $optin}
+                            <div class="checkbox">
+                                <label for="optin">
+                                    <input type="checkbox" name="optin" id="optin" value="1"{if isset($guestInformations) && isset($guestInformations.optin) && $guestInformations.optin} checked="checked"{/if} autocomplete="off"/>
+                                    {l s='Receive special offers from our partners!'}</label>
+                                {if array_key_exists('optin', $field_required)}
+                                    <sup> *</sup>
+                                {/if}
+                            </div>
+                        {/if}
+                        <h3 class="page-subheading top-indent">{l s='Delivery address'}</h3>
+                        {$stateExist = false}
+                        {$postCodeExist = false}
+                        {$dniExist = false}
+                        {foreach from=$dlv_all_fields item=field_name}
+                            {if $field_name eq "company"}
+                                <div class="text form-group">
+                                    <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                                    <input type="text" class="text form-control validate" id="company" name="company" data-validate="isGenericName" value="{if isset($guestInformations) && isset($guestInformations.company) && $guestInformations.company}{$guestInformations.company}{/if}" />
+                                </div>
+                            {elseif $field_name eq "dni"}
+                                {assign var='dniExist' value=true}
+                                <div class="required dni form-group">
+                                    <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+                                    <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+                                </div>
+                            {elseif $field_name eq "firstname"}
+                                <div class="required text form-group">
+                                    <label for="firstname">{l s='First name'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" id="firstname" name="firstname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname) && $guestInformations.firstname}{$guestInformations.firstname}{/if}" />
+                                </div>
+                            {elseif $field_name eq "lastname"}
+                                <div class="required text form-group">
+                                    <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" id="lastname" name="lastname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname) && $guestInformations.lastname}{$guestInformations.lastname}{/if}" />
+                                </div>
+                            {elseif $field_name eq "address1"}
+                                <div class="required text form-group">
+                                    <label for="address1">{l s='Address'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" name="address1" id="address1" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1) && isset($guestInformations) && isset($guestInformations.address1) && $guestInformations.address1}{$guestInformations.address1}{/if}" />
+                                </div>
+                            {elseif $field_name eq "address2"}
+                                <div class="text{if !in_array($field_name, $required_fields)} is_customer_param{/if} form-group">
+                                    <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                                    <input type="text" class="text form-control validate" name="address2" id="address2" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2) && isset($guestInformations) && isset($guestInformations.address2) && $guestInformations.address2}{$guestInformations.address2}{/if}" />
+                                </div>
+                            {elseif $field_name eq "postcode"}
+                                {$postCodeExist = true}
+                                <div class="required postcode text form-group">
+                                    <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+                                </div>
+                            {elseif $field_name eq "city"}
+                                <div class="required text form-group">
+                                    <label for="city">{l s='City'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" name="city" id="city" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city) && $guestInformations.city}{$guestInformations.city}{/if}" />
+                                </div>
+                            {elseif $field_name eq "country" || $field_name eq "Country:name"}
+                                <div class="required select form-group">
+                                    <label for="id_country">{l s='Country'} <sup>*</sup></label>
+                                    <select name="id_country" id="id_country" class="form-control">
+                                        {foreach from=$countries item=v}
+                                            <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
+                                        {/foreach}
+                                    </select>
+                                </div>
+                            {elseif $field_name eq "state" || $field_name eq 'State:name'}
+                                {$stateExist = true}
+                                <div class="required id_state form-group" style="display:none;">
+                                    <label for="id_state">{l s='State'} <sup>*</sup></label>
+                                    <select name="id_state" id="id_state" class="form-control">
+                                        <option value="">-</option>
+                                    </select>
+                                </div>
+                            {/if}
+                        {/foreach}
+                        {if !$postCodeExist}
+                            <div class="required postcode form-group unvisible">
+                                <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+                                <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+                            </div>
+                        {/if}
+                        {if !$stateExist}
+                            <div class="required id_state form-group unvisible">
+                                <label for="id_state">{l s='State'} <sup>*</sup></label>
+                                <select name="id_state" id="id_state" class="form-control">
+                                    <option value="">-</option>
+                                </select>
+                            </div>
+                        {/if}
+                        {if !$dniExist}
+                            <div class="required dni form-group">
+                                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                                <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+                                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+                            </div>
+                        {/if}
+                        <div class="form-group is_customer_param">
+                            <label for="other">{l s='Additional information'}</label>
+                            <textarea class="form-control" name="other" id="other" cols="26" rows="7"></textarea>
+                        </div>
+                        {if isset($one_phone_at_least) && $one_phone_at_least}
+                            <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
+                        {/if}
+                        <div class="form-group is_customer_param">
+                            <label for="phone">{l s='Home phone'}</label>
+                            <input type="text" class="text form-control validate" name="phone" id="phone"  data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone) && $guestInformations.phone}{$guestInformations.phone}{/if}" />
+                        </div>
+                        <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+                            <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
+                            <input type="text" class="text form-control validate" name="phone_mobile" id="phone_mobile" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile) && $guestInformations.phone_mobile}{$guestInformations.phone_mobile}{/if}" />
+                        </div>
+                        <input type="hidden" name="alias" id="alias" value="{l s='My address'}"/>
+
+                        <div class="checkbox">
+                            <label for="invoice_address">
+                                <input type="checkbox" name="invoice_address" id="invoice_address"{if (isset($smarty.post.invoice_address) && $smarty.post.invoice_address) || (isset($guestInformations) && isset($guestInformations.invoice_address) && $guestInformations.invoice_address)} checked="checked"{/if} autocomplete="off"/>
+                                {l s='Please use another address for invoice'}</label>
+                        </div>
+
+                        <div id="opc_invoice_address" class="is_customer_param">
+                            {assign var=stateExist value=false}
+                            {assign var=postCodeExist value=false}
+                            {assign var='dniExist' value=false}
+                            <h3 class="page-subheading top-indent">{l s='Invoice address'}</h3>
+                            {foreach from=$inv_all_fields item=field_name}
+                                {if $field_name eq "company"}
+                                    <div class="form-group">
+                                        <label for="company_invoice">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                                        <input type="text" class="text form-control validate" id="company_invoice" name="company_invoice"  data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.company_invoice) && $guestInformations.company_invoice}{$guestInformations.company_invoice}{/if}" />
+                                    </div>
+                                {elseif $field_name eq "dni"}
+                                    {assign var='dniExist' value=true}
+                                    <div class="required form-group dni_invoice">
+                                        <label for="dni_invoice">{l s='Identification number'} <sup>*</sup></label>
+                                        <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
+                                        <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+                                    </div>
+                                {elseif $field_name eq "firstname"}
+                                    <div class="required form-group">
+                                        <label for="firstname_invoice">{l s='First name'} <sup>*</sup></label>
+                                        <input type="text" class="form-control validate" id="firstname_invoice" name="firstname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname_invoice) && $guestInformations.firstname_invoice}{$guestInformations.firstname_invoice}{/if}" />
+                                    </div>
+                                {elseif $field_name eq "lastname"}
+                                    <div class="required form-group">
+                                        <label for="lastname_invoice">{l s='Last name'} <sup>*</sup></label>
+                                        <input type="text" class="form-control validate" id="lastname_invoice" name="lastname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname_invoice) && $guestInformations.lastname_invoice}{$guestInformations.lastname_invoice}{/if}" />
+                                    </div>
+                                {elseif $field_name eq "address1"}
+                                    <div class="required form-group">
+                                        <label for="address1_invoice">{l s='Address'} <sup>*</sup></label>
+                                        <input type="text" class="form-control validate" name="address1_invoice" id="address1_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1_invoice) && isset($guestInformations) && isset($guestInformations.address1_invoice) && $guestInformations.address1_invoice}{$guestInformations.address1_invoice}{/if}" />
+                                    </div>
+                                {elseif $field_name eq "address2"}
+                                    <div class="form-group{if !in_array($field_name, $required_fields)} is_customer_param{/if}">
+                                        <label for="address2_invoice">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                                        <input type="text" class="form-control address" name="address2_invoice" id="address2_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2_invoice) && isset($guestInformations) && isset($guestInformations.address2_invoice) && $guestInformations.address2_invoice}{$guestInformations.address2_invoice}{/if}" />
+                                    </div>
+                                {elseif $field_name eq "postcode"}
+                                    {$postCodeExist = true}
+                                    <div class="required postcode_invoice form-group">
+                                        <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+                                        <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
+                                    </div>
+                                {elseif $field_name eq "city"}
+                                    <div class="required form-group">
+                                        <label for="city_invoice">{l s='City'} <sup>*</sup></label>
+                                        <input type="text" class="form-control validate" name="city_invoice" id="city_invoice" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city_invoice) && $guestInformations.city_invoice}{$guestInformations.city_invoice}{/if}" />
+                                    </div>
+                                {elseif $field_name eq "country" || $field_name eq "Country:name"}
+                                    <div class="required form-group">
+                                        <label for="id_country_invoice">{l s='Country'} <sup>*</sup></label>
+                                        <select name="id_country_invoice" id="id_country_invoice" class="form-control">
+                                            <option value="">-</option>
+                                            {foreach from=$countries item=v}
+                                                <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
+                                            {/foreach}
+                                        </select>
+                                    </div>
+                                {elseif $field_name eq "state" || $field_name eq 'State:name'}
+                                    {$stateExist = true}
+                                    <div class="required id_state_invoice form-group" style="display:none;">
+                                        <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+                                        <select name="id_state_invoice" id="id_state_invoice" class="form-control">
+                                            <option value="">-</option>
+                                        </select>
+                                    </div>
+                                {/if}
+                            {/foreach}
+                            {if !$postCodeExist}
+                                <div class="required postcode_invoice form-group unvisible">
+                                    <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+                                    <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
+                                </div>
+                            {/if}
+                            {if !$stateExist}
+                                <div class="required id_state_invoice form-group unvisible">
+                                    <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+                                    <select name="id_state_invoice" id="id_state_invoice" class="form-control">
+                                        <option value="">-</option>
+                                    </select>
+                                </div>
+                            {/if}
+                            {if !$dniExist}
+                                <div class="required form-group dni_invoice">
+                                    <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                                    <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
+                                    <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+                                </div>
+                            {/if}
+                            <div class="form-group is_customer_param">
+                                <label for="other_invoice">{l s='Additional information'}</label>
+                                <textarea class="form-control" name="other_invoice" id="other_invoice" cols="26" rows="3"></textarea>
+                            </div>
+                            {if isset($one_phone_at_least) && $one_phone_at_least}
+                                <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
+                            {/if}
+                            <div class="form-group is_customer_param">
+                                <label for="phone_invoice">{l s='Home phone'}</label>
+                                <input type="text" class="form-control validate" name="phone_invoice" id="phone_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_invoice) && $guestInformations.phone_invoice}{$guestInformations.phone_invoice}{/if}" />
+                            </div>
+                            <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+                                <label for="phone_mobile_invoice">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
+                                <input type="text" class="form-control validate" name="phone_mobile_invoice" id="phone_mobile_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile_invoice) && $guestInformations.phone_mobile_invoice}{$guestInformations.phone_mobile_invoice}{/if}" />
+                            </div>
+                            <input type="hidden" name="alias_invoice" id="alias_invoice" value="{l s='My Invoice address'}" />
+                        </div>
+                        {block name='displayCustomerAccountForm'}
+                            {$HOOK_CREATE_ACCOUNT_FORM}
+                        {/block}
+                        {block name='order_opc_new_account_advanced_account_submit'}
+                            <div class="submit opc-add-save clearfix">
+                                <p class="required opc-required pull-right">
+                                    <sup>*</sup>{l s='Required field'}
+                                </p>
+                                <button type="submit" name="submitAccount" id="submitAccount" data-adv-api="1" class="btn btn-default button button-medium"><span>{l s='Save'}<i class="icon-chevron-right right"></i></span></button>
+                            </div>
+                        {/block}
+                        <div style="display: none;" id="opc_account_saved" class="alert alert-success">
+                            {l s='Account information saved successfully'}
+                        </div>
+                        <!-- END Account -->
+                    </div>
+                </div>
+            </fieldset>
+        </form>
+    {/block}
+</div>
+{block name='order_opc_new_account_advanced_js_vars'}
+    {strip}
+        {if isset($guestInformations) && isset($guestInformations.id_state) && $guestInformations.id_state}
+            {addJsDef idSelectedState=$guestInformations.id_state|intval}
+        {else}
+            {addJsDef idSelectedState=false}
+        {/if}
+        {if isset($guestInformations) && isset($guestInformations.id_state_invoice) && $guestInformations.id_state_invoice}
+            {addJsDef idSelectedStateInvoice=$guestInformations.id_state_invoice|intval}
+        {else}
+            {addJsDef idSelectedStateInvoice=false}
+        {/if}
+        {if isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country}
+            {addJsDef idSelectedCountry=$guestInformations.id_country|intval}
+        {else}
+            {addJsDef idSelectedCountry=false}
+        {/if}
+        {if isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice}
+            {addJsDef idSelectedCountryInvoice=$guestInformations.id_country_invoice|intval}
+        {else}
+            {addJsDef idSelectedCountryInvoice=false}
+        {/if}
+        {if isset($countries)}
+            {addJsDef countries=$countries}
+        {/if}
+    {/strip}
+{/block}

--- a/themes/hotel-reservation-theme/order-opc-new-account.tpl
+++ b/themes/hotel-reservation-theme/order-opc-new-account.tpl
@@ -1,1 +1,419 @@
-{extends file='checkout-inquiry.tpl'}
+<div id="opc_new_account" class="opc-main-block">
+	<div id="opc_new_account-overlay" class="opc-overlay" style="display: none;"></div>
+	{block name='order_opc_new_account_login_form'}
+		<form action="{$link->getPageLink('authentication', true, NULL, "back=order-opc")|escape:'html':'UTF-8'}" method="post" id="login_form">
+			<fieldset>
+				<div class="already_registered_block">
+					<p>
+						{l s='Already have an account?'} <a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" id="openLoginFormBlock"> {l s='Login now'}</a> {l s='to make checkout process faster and time saving.'}
+					</p>
+					<p>{l s='Or'}</p>
+				</div>
+				<div id="login_form_content" style="display:none;">
+					<p class="text-secondary"><a href="#" id="idAccountChoice"> {l s='Return'}</a> {l s='to other checkout options.'}</p>
+					<!-- Error return block -->
+					<div id="opc_login_errors" class="alert alert-danger" style="display:none;"></div>
+					<!-- END Error return block -->
+					<div class="row">
+						<div class="form-group col-sm-6">
+							<label for="login_email">{l s='Email address'}</label>
+							<input type="email" class="form-control validate" id="login_email" name="email" data-validate="isEmail" />
+						</div>
+					</div>
+					<div class="row">
+						<div class="form-group col-sm-6">
+							<label for="login_passwd">{l s='Password'}</label>
+							<input class="form-control validate" type="password" id="login_passwd" name="login_passwd" data-validate="isPasswd" />
+						</div>
+					</div>
+					{block name='displayLoginFormFieldsAfter'}
+						{hook h='displayLoginFormFieldsAfter'}
+					{/block}
+					<a href="{$link->getPageLink('password', true)|escape:'html':'UTF-8'}" class="lost_password pull-right">{l s='Forgot your password?'}</a>
+					<div style="clear:both"></div>
+					{block name='order_opc_new_account_login_submit'}
+						<p class="submit">
+							{if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
+							<button type="submit" id="SubmitLogin" name="SubmitLogin" class="button btn btn-default button-medium pull-right"><span>{l s='Sign in'}</span></button>
+						</p>
+					{/block}
+					{block name='displayLoginFormBottom'}
+						{hook h='displayLoginFormBottom'}
+					{/block}
+				</div>
+			</fieldset>
+		</form>
+	{/block}
+	{block name='order_opc_new_account_new_account_form'}
+		<form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="new_account_form" class="std" autocomplete="on" autofill="on">
+			<div id="opc_account_choice" class="row">
+				<div class="col-xs-12">
+					<div class="opc-button">
+						<span>
+							<button type="submit" class="opc-button-small opc-btn-primary" id="opc_guestCheckout"><span>{l s='Guest checkout'}</span></button>
+						</span>
+						<span>
+							<button type="submit" class="opc-button-small opc-btn-default" id="opc_createAccount"><span>{l s='Create an account'}</span></button>
+						</span>
+					</div>
+				</div>
+			</div>
+			<div id="opc_account_form" class="unvisible">
+				{block name='displayCustomerAccountFormTop'}
+					{$HOOK_CREATE_ACCOUNT_TOP}
+				{/block}
+				<div style="display: none;" id="opc_account_saved" class="alert alert-success">
+					{l s='Account information saved successfully.'}
+				</div>
+				<!-- Error return block -->
+				<div id="opc_account_errors" class="alert alert-danger" style="display:none;"></div>
+				<!-- END Error return block -->
+				<div style="display: none; margin-top: 15px;" id="opc_account_saved" class="alert alert-success">
+					{l s='Account information saved successfully.'}
+				</div>
+				<!-- Account -->
+				<input type="hidden" id="is_new_customer" name="is_new_customer" value="0" />
+				<input type="hidden" id="opc_id_customer" name="opc_id_customer" value="{if isset($guestInformations) && isset($guestInformations.id_customer) && $guestInformations.id_customer}{$guestInformations.id_customer}{else}0{/if}" />
+				<input type="hidden" id="opc_id_address_delivery" name="opc_id_address_delivery" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+				<input type="hidden" id="opc_id_address_invoice" name="opc_id_address_invoice" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+				<p class="required"><sup>*</sup>{l s='Required field'}</p>
+
+				<div class="row">
+					<div class="required clearfix gender-line col-sm-2">
+						<label>{l s='Social title'}</label>
+						<select name="id_gender" id="id_gender">
+							{foreach from=$genders key=k item=gender}
+								<option value="{$gender->id_gender}"{if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id_gender || (isset($guestInformations) && $guestInformations.id_gender == $gender->id_gender)} selected="selected"{/if}>{$gender->name}</option>
+							{/foreach}
+						</select>
+					</div>
+					<div class="required form-group col-sm-5">
+						<label for="firstname">{l s='First name'} <sup>*</sup></label>
+						<input type="text" class="text form-control validate" id="customer_firstname" name="customer_firstname" onblur="$('#firstname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_firstname) && $guestInformations.customer_firstname}{$guestInformations.customer_firstname}{/if}" />
+					</div>
+					<div class="required form-group col-sm-5">
+						<label for="lastname">{l s='Last name'} <sup>*</sup></label>
+						<input type="text" class="form-control validate" id="customer_lastname" name="customer_lastname" onblur="$('#lastname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_lastname) && $guestInformations.customer_lastname}{$guestInformations.customer_lastname}{/if}" />
+					</div>
+				</div>
+
+				<div class="row">
+					<div class="required text form-group col-sm-6">
+						<label for="email">{l s='Email'} <sup>*</sup></label>
+						<input type="email" class="text form-control validate" id="email" name="email" data-validate="isEmail" value="{if isset($guestInformations) && isset($guestInformations.email) && $guestInformations.email}{$guestInformations.email}{/if}" />
+					</div>
+				</div>
+				<div class="row">
+					<div class="required password is_customer_param form-group col-sm-6">
+						<label for="passwd">{l s='Password'} <sup>*</sup></label>
+						<input type="password" class="text form-control validate" name="passwd" id="passwd" data-validate="isPasswd" />
+						<span class="form_info">{l s='(five characters min.)'}</span>
+					</div>
+				</div>
+				<div class="row">
+					<div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group col-sm-6">
+						<label for="customer_phone">{l s='Phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
+						<input type="text" class="text form-control validate" name="customer_phone" id="customer_phone" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile) && $guestInformations.phone_mobile}{$guestInformations.phone_mobile}{/if}" onblur="$('#phone').val($(this).val());"/>
+					</div>
+				</div>
+				{if isset($PS_REGISTRATION_PROCESS_TYPE) && $PS_REGISTRATION_PROCESS_TYPE}
+					{if isset($birthday) && $birthday}
+						<div class="row">
+							<div class="select form-group date-select col-sm-12">
+								<label>{l s='Date of Birth'}</label>
+								<div class="row">
+									<div class="col-xs-4">
+										<select id="days" name="days">
+											<option value="">-</option>
+											{foreach from=$days item=day}
+											<option value="{$day|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_day) && ($guestInformations.sl_day == $day)} selected="selected"{/if}>{$day|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+											{/foreach}
+										</select>
+									</div>
+									<div class="col-xs-4">
+										<select id="months" name="months">
+											<option value="">-</option>
+											{foreach from=$months key=k item=month}
+											<option value="{$k|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_month) && ($guestInformations.sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
+											{/foreach}
+										</select>
+									</div>
+									<div class="col-xs-4">
+										<select id="years" name="years">
+											<option value="">-</option>
+											{foreach from=$years item=year}
+											<option value="{$year|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_year) && ($guestInformations.sl_year == $year)} selected="selected"{/if}>{$year|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+											{/foreach}
+										</select>
+									</div>
+								</div>
+							</div>
+						</div>
+					{/if}
+					{if isset($newsletter) && $newsletter}
+						<div class="checkbox">
+							<label for="newsletter">
+							<input type="checkbox" name="newsletter" id="newsletter" value="1"{if isset($guestInformations) && isset($guestInformations.newsletter) && $guestInformations.newsletter} checked="checked"{/if} autocomplete="off"/>
+							{l s='Sign up for our newsletter!'}</label>
+							{if array_key_exists('newsletter', $field_required)}
+								<sup> *</sup>
+							{/if}
+						</div>
+					{/if}
+					{if isset($optin) && $optin}
+						<div class="checkbox">
+							<label for="optin">
+							<input type="checkbox" name="optin" id="optin" value="1"{if isset($guestInformations) && isset($guestInformations.optin) && $guestInformations.optin} checked="checked"{/if} autocomplete="off"/>
+							{l s='Receive special offers from our partners!'}</label>
+							{if array_key_exists('optin', $field_required)}
+								<sup> *</sup>
+							{/if}
+						</div>
+					{/if}
+
+					<p class="block-small-header margin-top-20 margin-btm-10">{l s='RESIDENTIAL ADDRESS'}</p>
+					{$stateExist = false}
+					{$postCodeExist = false}
+					{$dniExist = false}
+					<div class="row">
+						{foreach from=$dlv_all_fields item=field_name}
+							{if $field_name eq "firstname"}
+								<div class="required text form-group col-sm-6">
+									<label for="firstname">{l s='First name'} <sup>*</sup></label>
+									<input type="text" class="text form-control validate" id="firstname" name="firstname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname) && $guestInformations.firstname}{$guestInformations.firstname}{/if}" />
+								</div>
+							{elseif $field_name eq "lastname"}
+								<div class="required text form-group col-sm-6">
+									<label for="lastname">{l s='Last name'} <sup>*</sup></label>
+									<input type="text" class="text form-control validate" id="lastname" name="lastname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname) && $guestInformations.lastname}{$guestInformations.lastname}{/if}" />
+								</div>
+							{elseif $field_name eq "address1"}
+								<div class="required text form-group col-sm-6">
+									<label for="address1">{l s='Address'} <sup>*</sup></label>
+									<input type="text" class="text form-control validate" name="address1" id="address1" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1) && isset($guestInformations) && isset($guestInformations.address1) && $guestInformations.address1}{$guestInformations.address1}{/if}" />
+								</div>
+							{elseif $field_name eq "address2"}
+								<div class="text{if !in_array($field_name, $required_fields)} is_customer_param{/if} form-group col-sm-6">
+									<label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+									<input type="text" class="text form-control validate" name="address2" id="address2" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2) && isset($guestInformations) && isset($guestInformations.address2) && $guestInformations.address2}{$guestInformations.address2}{/if}" />
+								</div>
+							{elseif $field_name eq "city"}
+								<div class="required text form-group col-sm-6">
+									<label for="city">{l s='City'} <sup>*</sup></label>
+									<input type="text" class="text form-control validate" name="city" id="city" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city) && $guestInformations.city}{$guestInformations.city}{/if}" />
+								</div>
+							{elseif $field_name eq "postcode"}
+								{$postCodeExist = true}
+								<div class="required postcode text form-group col-sm-6">
+									<label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+									<input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+								</div>
+							{elseif $field_name eq "company"}
+								<div class="text form-group col-sm-6">
+									<label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+									<input type="text" class="text form-control validate" id="company" name="company" data-validate="isGenericName" value="{if isset($guestInformations) && isset($guestInformations.company) && $guestInformations.company}{$guestInformations.company}{/if}" />
+								</div>
+							{elseif $field_name eq "dni"}
+								{assign var='dniExist' value=true}
+								<div class="required dni form-group col-sm-6">
+									<label for="dni">{l s='Identification number'} <sup>*</sup></label>
+									<input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+									<span class="form_info">{l s='DNI / NIF / NIE'}</span>
+								</div>
+							{elseif $field_name eq "country" || $field_name eq "Country:name"}
+								<div class="required select form-group col-sm-6">
+									<label for="id_country">{l s='Country'} <sup>*</sup></label>
+									<select name="id_country" id="id_country">
+										{foreach from=$countries item=v}
+										<option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
+										{/foreach}
+									</select>
+								</div>
+							{elseif $field_name eq "state" || $field_name eq 'State:name'}
+								{$stateExist = true}
+								<div class="required id_state form-group col-sm-6" style="display:none;">
+									<label for="id_state">{l s='State'} <sup>*</sup></label>
+									<select name="id_state" id="id_state">
+										<option value="">-</option>
+									</select>
+								</div>
+							{/if}
+						{/foreach}
+						{if !$postCodeExist}
+							<div class="required postcode form-group col-sm-6 unvisible">
+								<label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+								<input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+							</div>
+						{/if}
+						{if !$stateExist}
+							<div class="required id_state form-group col-sm-6 unvisible">
+								<label for="id_state">{l s='State'} <sup>*</sup></label>
+								<select name="id_state" id="id_state">
+									<option value="">-</option>
+								</select>
+							</div>
+						{/if}
+						{if !$dniExist}
+							<div class="required dni form-group col-sm-6">
+								<label for="dni">{l s='Identification number'} <sup>*</sup></label>
+								<input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+								<span class="form_info">{l s='DNI / NIF / NIE'}</span>
+							</div>
+						{/if}
+						<div class="form-group is_customer_param col-sm-6">
+							<label for="phone">{l s='Home phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+							<input type="text" class="text form-control validate" name="phone" id="phone" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone) && $guestInformations.phone}{$guestInformations.phone}{/if}" />
+						</div>
+						<div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group col-sm-6">
+							<label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+							<input type="text" class="text form-control validate" name="phone_mobile" id="phone_mobile" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile) && $guestInformations.phone_mobile}{$guestInformations.phone_mobile}{/if}" />
+						</div>
+						<div class="form-group is_customer_param col-sm-6">
+							<label for="other">{l s='Additional information'}</label>
+							<textarea class="form-control" name="other" id="other" cols="26" rows="7"></textarea>
+						</div>
+					</div>
+					<div class="row">
+						<div class="col-sm-12">
+							{if isset($one_phone_at_least) && $one_phone_at_least}
+								{assign var="atLeastOneExists" value=true}
+								<p class="inline-infos required">** {l s='You must register at least one phone number.'}</p>
+							{/if}
+							<input type="hidden" name="alias" id="alias" value="{l s='My address'}"/>
+
+							{* <div class="checkbox">
+								<label for="invoice_address">
+								<input type="checkbox" name="invoice_address" id="invoice_address"{if (isset($smarty.post.invoice_address) && $smarty.post.invoice_address) || (isset($guestInformations) && isset($guestInformations.invoice_address) && $guestInformations.invoice_address)} checked="checked"{/if} autocomplete="off"/>
+								{l s='Please use another address for invoice'}</label>
+							</div> *}
+							<p class="required opc-required">
+								<sup>*</sup>{l s='Required field'}
+							</p>
+						</div>
+					</div>
+				{/if}
+				{* <div id="opc_invoice_address" class="is_customer_param">
+					{assign var=stateExist value=false}
+					{assign var=postCodeExist value=false}
+					{assign var='dniExist' value=false}
+					<h3 class="page-subheading top-indent">{l s='Additional address'}</h3>
+					{foreach from=$inv_all_fields item=field_name}
+						{if $field_name eq "company"}
+							<div class="form-group">
+								<label for="company_invoice">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+								<input type="text" class="text form-control validate" id="company_invoice" name="company_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.company_invoice) && $guestInformations.company_invoice}{$guestInformations.company_invoice}{/if}" />
+							</div>
+						{elseif $field_name eq "dni"}
+							{assign var='dniExist' value=true}
+							<div class="required form-group dni_invoice">
+								<label for="dni_invoice">{l s='Identification number'} <sup>*</sup></label>
+								<input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
+								<span class="form_info">{l s='DNI / NIF / NIE'}</span>
+							</div>
+						{elseif $field_name eq "firstname"}
+							<div class="required form-group">
+								<label for="firstname_invoice">{l s='First name'} <sup>*</sup></label>
+								<input type="text" class="form-control validate" id="firstname_invoice" name="firstname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname_invoice) && $guestInformations.firstname_invoice}{$guestInformations.firstname_invoice}{/if}" />
+							</div>
+						{elseif $field_name eq "lastname"}
+							<div class="required form-group">
+								<label for="lastname_invoice">{l s='Last name'} <sup>*</sup></label>
+								<input type="text" class="form-control validate" id="lastname_invoice" name="lastname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname_invoice) && $guestInformations.lastname_invoice}{$guestInformations.lastname_invoice}{/if}" />
+							</div>
+						{elseif $field_name eq "address1"}
+							<div class="required form-group">
+								<label for="address1_invoice">{l s='Address'} <sup>*</sup></label>
+								<input type="text" class="form-control validate" name="address1_invoice" id="address1_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1_invoice) && isset($guestInformations) && isset($guestInformations.address1_invoice) && $guestInformations.address1_invoice}{$guestInformations.address1_invoice}{/if}" />
+							</div>
+						{elseif $field_name eq "address2"}
+							<div class="form-group{if !in_array($field_name, $required_fields)} is_customer_param{/if}">
+								<label for="address2_invoice">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+								<input type="text" class="form-control address" name="address2_invoice" id="address2_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2_invoice) && isset($guestInformations) && isset($guestInformations.address2_invoice) && $guestInformations.address2_invoice}{$guestInformations.address2_invoice}{/if}" />
+							</div>
+						{elseif $field_name eq "postcode"}
+							{$postCodeExist = true}
+							<div class="required postcode_invoice form-group">
+								<label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+								<input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
+							</div>
+						{elseif $field_name eq "city"}
+							<div class="required form-group">
+								<label for="city_invoice">{l s='City'} <sup>*</sup></label>
+								<input type="text" class="form-control validate" name="city_invoice" id="city_invoice" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city_invoice) && $guestInformations.city_invoice}{$guestInformations.city_invoice}{/if}" />
+							</div>
+						{elseif $field_name eq "country" || $field_name eq "Country:name"}
+							<div class="required form-group">
+								<label for="id_country_invoice">{l s='Country'} <sup>*</sup></label>
+								<select name="id_country_invoice" id="id_country_invoice" class="form-control">
+									<option value="">-</option>
+									{foreach from=$countries item=v}
+									<option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
+									{/foreach}
+								</select>
+							</div>
+						{elseif $field_name eq "state" || $field_name eq 'State:name'}
+							{$stateExist = true}
+							<div class="required id_state_invoice form-group" style="display:none;">
+								<label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+								<select name="id_state_invoice" id="id_state_invoice" class="form-control">
+									<option value="">-</option>
+								</select>
+							</div>
+						{/if}
+					{/foreach}
+					{if !$postCodeExist}
+						<div class="required postcode_invoice form-group unvisible">
+							<label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+							<input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
+						</div>
+					{/if}
+					{if !$stateExist}
+						<div class="required id_state_invoice form-group unvisible">
+							<label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+							<select name="id_state_invoice" id="id_state_invoice" class="form-control">
+								<option value="">-</option>
+							</select>
+						</div>
+					{/if}
+					{if !$dniExist}
+						<div class="required form-group dni_invoice">
+							<label for="dni">{l s='Identification number'} <sup>*</sup></label>
+							<input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
+							<span class="form_info">{l s='DNI / NIF / NIE'}</span>
+						</div>
+					{/if}
+						<div class="form-group is_customer_param">
+							<label for="other_invoice">{l s='Additional information'}</label>
+							<textarea class="form-control" name="other_invoice" id="other_invoice" cols="26" rows="3"></textarea>
+						</div>
+					{if isset($one_phone_at_least) && $one_phone_at_least}
+						<p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
+					{/if}
+					<div class="form-group is_customer_param">
+						<label for="phone_invoice">{l s='Home phone'}</label>
+						<input type="text" class="form-control validate" name="phone_invoice" id="phone_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_invoice) && $guestInformations.phone_invoice}{$guestInformations.phone_invoice}{/if}" />
+					</div>
+					<div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+						<label for="phone_mobile_invoice">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
+						<input type="text" class="form-control validate" name="phone_mobile_invoice" id="phone_mobile_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile_invoice) && $guestInformations.phone_mobile_invoice}{$guestInformations.phone_mobile_invoice}{/if}" />
+					</div>
+					<input type="hidden" name="alias_invoice" id="alias_invoice" value="{l s='My Invoice address'}" />
+				</div> *}
+				{block name='displayCustomerAccountForm'}
+					{$HOOK_CREATE_ACCOUNT_FORM}
+				{/block}
+				{block name='order_opc_new_account_submit'}
+					<div class="submit opc-add-save clearfix">
+						<button type="submit" name="submitAccount" id="submitAccount" class="btn btn-default button button-medium pull-right"><span>{l s='Save'}<i class="icon-chevron-right right"></i></span></button>
+					</div>
+				{/block}
+			<!-- END Account -->
+			</div>
+		</form>
+	{/block}
+</div>
+{strip}
+	{if isset($countries)}
+		{addJsDef countries=$countries}
+	{/if}
+{/strip}

--- a/themes/hotel-reservation-theme/order-opc.tpl
+++ b/themes/hotel-reservation-theme/order-opc.tpl
@@ -1,1 +1,405 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{block name='order_opc'}
+	{if $opc}
+		{assign var="back_order_page" value="order-opc.php"}
+		{else}
+		{assign var="back_order_page" value="order.php"}
+	{/if}
+
+	<section id="wrapper">
+		<div class="container">
+			<section id="content">
+				<div class="row">
+					{if $PS_CATALOG_MODE}
+						{capture name=path}{l s='Your booking cart'}{/capture}
+						{block name='order_opc_heading'}
+							<h2 class="page-heading">{l s='Your booking cart'}</h2>
+						{/block}
+
+						<p class="alert alert-warning">{l s='The hotel is currently not accepting any bookings.'}</p>
+					{else}
+						{if $productNumber}
+
+							{block name='order_opc_left_column'}
+								<div class="col-md-8">
+            						{block name='errors'}
+										{include file="$tpl_dir./errors.tpl"}
+									{/block}
+
+									{* Accordian for all blocks *}
+									<div class="accordion" id="oprder-opc-accordion">
+										<input type="hidden" name="opc_id_address_delivery" value="{$cart->id_address_delivery}" id="opc_id_address_delivery" />
+										<input type="hidden" name="opc_id_address_invoice" value="{$cart->id_address_invoice}" id="opc_id_address_invoice" />
+										{if isset($checkout_process_steps) && $checkout_process_steps}
+											{foreach $checkout_process_steps as $step}
+												{if $step->step_key == 'checkout_rooms_summary'}
+													{block name='order_opc_rooms_summary'}
+														<div class="card">
+															<div class="card-header" id="shopping-cart-summary-head">
+																{block name='order_opc_rooms_summary_heading'}
+																	<h5 class="accordion-header" data-toggle="collapse" data-target="#collapse-shopping-cart" aria-expanded="true" aria-controls="collapse-shopping-cart">
+																		<span>{l s='Rooms & Price Summary'}</span>
+																		<i class="icon-angle-left pull-right accordion-left-arrow {if $step->step_is_current}hidden{/if}"></i>
+																	</h5>
+																{/block}
+															</div>
+															{if $step->step_is_reachable}
+																<div id="collapse-shopping-cart" class="opc-collapse {if !$step->step_is_current}collapse{/if}" aria-labelledby="shopping-cart-head" data-parent="#oprder-opc-accordion">
+																	<div class="card-body">
+																		{* This tpl includes room type lists in the orders *}
+																		{block name='shopping_cart'}
+																			{include file="$tpl_dir./shopping-cart.tpl"}
+																		{/block}
+																	</div>
+																</div>
+															{/if}
+														</div>
+													{/block}
+												{* End Shopping Cart *}
+												{elseif $step->step_key == 'checkout_customer'}
+													{block name='order_opc_guest_information'}
+														<div class="card" id="guest-info-block">
+															<div class="card-header" id="guest-info-head">
+																{block name='order_opc_guest_information_heading'}
+																	<h5 class="accordion-header" data-toggle="collapse" data-target="#collapse-guest-info" aria-expanded="true" aria-controls="collapse-guest-info">
+																		<span>{l s='Guest Information'}</span>
+																		<i class="icon-angle-left pull-right accordion-left-arrow {if $step->step_is_current}hidden{/if}"></i>
+																	</h5>
+																{/block}
+															</div>
+															{if $step->step_is_reachable}
+																{block name='order_opc_guest_detail_wrapper'}
+																	<div id="collapse-guest-info" class="opc-collapse {if !$step->step_is_current}collapse{/if}" aria-labelledby="guest-info-head" data-parent="#oprder-opc-accordion">
+																		<div class="card-body">
+																			{if $is_logged || $isGuest}
+																				{if $is_logged}
+																					{block name='order_opc_guest_detail_form'}
+																						<form id="customer_guest_detail_form" method="post" action="{$link->getPageLink('order-opc', null, null)}">
+																							<input type="hidden" name="submitGuestDetails" value="1">
+																							<p class="checkbox">
+																								<input type="checkbox" name="customer_guest_detail" id="customer_guest_detail" value="1" {if $id_customer_guest_detail}checked="checked"{/if}/>
+																								<label for="customer_guest_detail" id="customer_guest_detail_txt">{l s='Booking for someone else?'}</label>
+																							</p>
+																							{if isset($customerGuestDetailErrors) && $customerGuestDetailErrors}
+																								<div class="alert alert-danger" id="customer_guest_detail_errors">
+																									<p>{if $customerGuestDetailErrors|@count > 1}{l s='There are %d errors' sprintf=$customerGuestDetailErrors|@count}{else}{l s='There is %d error' sprintf=$customerGuestDetailErrors|@count}{/if}</p>
+																									<ol>
+																										{foreach from=$customerGuestDetailErrors key=k item=customerGuestDetailError}
+																											<li>{$customerGuestDetailError}</li>
+																										{/foreach}
+																									</ol>
+																								</div>
+																							{/if}
+																							<div id="customer-guest-detail-container" {if !$id_customer_guest_detail}style="display: none;"{/if}>
+																								<div class="row">
+																									<div class="required clearfix gender-line col-sm-2">
+																										<label>{l s='Social title'}</label>
+																										<select name="customer_guest_detail_gender" id="customer_guest_detail_gender">
+																											{foreach from=$genders key=k item=gender}
+																												<option value="{$gender->id_gender}"{if isset($smarty.post.customer_guest_detail_gender) && $smarty.post.customer_guest_detail_gender == $gender->id_gender || (isset($customer_guest_detail) && $customer_guest_detail.id_gender == $gender->id_gender)} selected="selected"{/if}>{$gender->name}</option>
+																											{/foreach}
+																										</select>
+																									</div>
+																									<div class="required form-group col-sm-5">
+																										<label for="firstname">{l s='First name'} <sup>*</sup></label>
+																										<input type="text" class="text form-control validate is_required" id="customer_guest_detail_firstname" name="customer_guest_detail_firstname" data-validate="isName" data-maxSize="32"{if isset($smarty.post.customer_guest_detail_firstname) && $smarty.post.customer_guest_detail_firstname}  value="{$smarty.post.customer_guest_detail_firstname}"{elseif isset($customer_guest_detail) && $customer_guest_detail.firstname} value="{$customer_guest_detail.firstname}"{/if}/>
+																									</div>
+																									<div class="required form-group col-sm-5">
+																										<label for="lastname">{l s='Last name'} <sup>*</sup></label>
+																										<input type="text" class="form-control validate is_required" id="customer_guest_detail_lastname" name="customer_guest_detail_lastname" data-validate="isName" data-maxSize="32"{if isset($smarty.post.customer_guest_detail_lastname) && $smarty.post.customer_guest_detail_lastname}  value="{$smarty.post.customer_guest_detail_lastname}"{elseif isset($customer_guest_detail) && $customer_guest_detail.lastname} value="{$customer_guest_detail.lastname}"{/if}/>
+																									</div>
+																								</div>
+																								<div class="row">
+																									<div class="required text form-group col-sm-6">
+																										<label for="email">{l s='Email'} <sup>*</sup></label>
+																										<input type="email" class="text form-control validate is_required" id="customer_guest_detail_email" name="customer_guest_detail_email" data-validate="isEmail" data-maxSize="128"{if isset($smarty.post.customer_guest_detail_email) && $smarty.post.customer_guest_detail_email}  value="{$smarty.post.customer_guest_detail_email}"{elseif isset($customer_guest_detail) && $customer_guest_detail.email} value="{$customer_guest_detail.email}"{/if}/>
+																									</div>
+																								</div>
+																								<div class="row">
+																									<div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group col-sm-6">
+																										<label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+																										<input type="text" class="text form-control validate is_required" name="customer_guest_detail_phone" id="customer_guest_detail_phone" data-validate="isPhoneNumber" data-maxSize="32"{if isset($smarty.post.customer_guest_detail_phone) && $smarty.post.customer_guest_detail_phone}  value="{$smarty.post.customer_guest_detail_phone}"{elseif isset($customer_guest_detail) && $customer_guest_detail.phone} value="{$customer_guest_detail.phone}"{/if}/>
+																									</div>
+																								</div>
+																							</div>
+																						</form>
+																					{/block}
+																				{/if}
+																				{block name='order_opc_guest_detail'}
+																					<div id="checkout-guest-info-block"  {if $id_customer_guest_detail}style="display: none;"{/if}>
+																						<div class="row margin-btm-10">
+																							<div class="col-sm-3 col-xs-5 info-head">{l s='Name'}</div>
+																							<div class="col-sm-9 col-xs-7 info-value">
+																								{if $isGuest}
+																									{$guestInformations['customer_firstname']|escape:'html':'UTF-8'} {$guestInformations['customer_lastname']|escape:'html':'UTF-8'}
+																								{else}
+																									{$guestInformations['firstname']|escape:'html':'UTF-8'} {$guestInformations['lastname']|escape:'html':'UTF-8'}
+																								{/if}
+																							</div>
+																						</div>
+																						<div class="row margin-btm-10">
+																							<div class="col-sm-3 col-xs-5 info-head">{l s='Email'}</div>
+																							<div class="col-sm-9 col-xs-7 info-value">{$guestInformations['email']|escape:'html':'UTF-8'}</div>
+																						</div>
+																						{if (isset({$guestInformations['phone']}) && {$guestInformations['phone']})}
+																							<div class="row margin-btm-10">
+																								<div class="col-sm-3 col-xs-5 info-head">
+																									{l s='Phone Number'}
+																								</div>
+																								<div class="col-sm-9 col-xs-7 info-value">
+																									{$guestInformations['phone']|escape:'html':'UTF-8'}
+																								</div>
+																							</div>
+																						{/if}
+																					</div>
+																				{/block}
+
+																				{* proceed only if no order restrict errors are there *}
+																				{if !$orderRestrictErr}
+																					{block name='order_opc_guest_detail_proceed_action'}
+																						<hr>
+																						<div class="row">
+																							<div class="col-sm-12 proceed_btn_block">
+																								<a class="btn btn-default button button-medium pull-right submit-guest-details" href="{$link->getPageLink('order-opc', null, null, ['proceed_to_payment' => 1])}" title="Proceed to Payment" rel="nofollow">
+																									<span>
+																										{l s='Proceed'}
+																									</span>
+																								</a>
+																								{if $isGuest}
+																									<a class="btn btn-default btn-edit-guest-info pull-right" href="#" rel="nofollow">
+																										<span>
+																											{l s='Edit'}
+																										</span>
+																									</a>
+																								{/if}
+																							</div>
+																						</div>
+																					{/block}
+																				{/if}
+																			{else}
+																				<!-- Create account / Guest account / Login block -->
+																				{block name='order_opc_new_account'}
+																					{include file="$tpl_dir./order-opc-new-account.tpl"}
+																				{/block}
+																			{/if}
+																		</div>
+																		{if $is_logged || $isGuest}
+																			<div class="card-body hidden" id="order-opc-edit-guest-info">
+																				{block name='order_opc_edit_guest_info'}
+																					{include file="./order-opc-edit-guest-info.tpl"}
+																				{/block}
+																			</div>
+																		{/if}
+																	</div>
+																{/block}
+															{/if}
+														</div>
+													{/block}
+												{elseif $step->step_key == 'checkout_payment'}
+													{block name='order_opc_payment'}
+														{* <div class="card col-sm-12">
+															<!-- Carrier -->
+															{include file="$tpl_dir./order-carrier.tpl"}
+															<!-- END Carrier -->
+														</div> *}
+														<div class="card">
+															<div class="card-header" id="order-payment-head">
+																{block name='order_opc_payment_heading'}
+																	<h5 class="accordion-header" data-toggle="collapse" data-target="#collapse-order-payment" aria-expanded="true" aria-controls="collapse-order-payment">
+																		<span>{l s='Payment Information'}</span>
+																		<i class="icon-angle-left pull-right accordion-left-arrow {if $step->step_is_current}hidden{/if}"></i>
+																	</h5>
+																{/block}
+															</div>
+															{if $step->step_is_reachable}
+																<div id="collapse-order-payment" class="opc-collapse {if !$step->step_is_current}collapse{/if}" aria-labelledby="order-payment-head" data-parent="#oprder-opc-accordion">
+																	<div class="card-body">
+																		<!-- Payment -->
+																		{block name='order_payment'}
+																			{include file="$tpl_dir./order-payment.tpl"}
+																		{/block}
+																		<!-- END Payment -->
+																	</div>
+																</div>
+															{/if}
+														</div>
+													{/block}
+												{/if}
+											{/foreach}
+										{/if}
+									</div>
+								</div>
+							{/block}
+							{block name='order_opc_right_column'}
+								<div class="col-md-4">
+									{block name='order_opc_cart_total_detail'}
+										{* Total cart details, tax details, advance payment details and voucher details *}
+										{include file="$tpl_dir./cart-total-block.tpl"}
+									{/block}
+									{block name='order_opc_vouchers'}
+										{* Check if voucher feature is enabled currently *}
+										{if $voucherAllowed}
+											{* Cart vouchers block *}
+											<div class="col-sm-12 card cart_voucher_detail_block">
+												<p class="cart_voucher_head">{l s='Apply Coupon'}</p>
+												<p><span>{l s='Have promocode ?'}</span></p>
+												{* Applied vouchers to the cart *}
+												{if sizeof($discounts)}
+													<div class="row">
+														{foreach $discounts as $discount}
+															<div class="col-sm-12 margin-btm-10 cart_discount {if $discount@last}last_item{elseif $discount@first}first_item{else}item{/if}" id="cart_discount_{$discount.id_discount}">
+																<span class="cart_discount_name">
+																	{$discount.name|escape:'html':'UTF-8'}
+																	{if strlen($discount.code)}
+																		<a
+																			href="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}?deleteDiscount={$discount.id_discount}"
+																			class="price_discount_delete pull-right"
+																			title="{l s='Delete'}">
+																			<i class="icon-times"></i>
+																		</a>
+																	{/if}
+																</span>
+																<span class="voucher_apply_state pull-right">
+																	<img src="{$img_dir}/icon/form-ok-circle.svg" /> {l s='Applied'}
+																</span>
+															</div>
+														{/foreach}
+													</div>
+													<hr class="seperator">
+												{/if}
+												<div class="row margin-btm-20">
+													{* Form to apply voucher to the cart *}
+													<form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+														<div class="col-sm-8 col-xs-12 col-md-12 col-lg-8">
+															<input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+															<input type="hidden" name="submitDiscount" />
+														</div>
+														<div class="col-sm-4 col-xs-12 col-md-12 col-lg-4 submit_discount_div">
+															<button type="submit" name="submitAddDiscount" class="opc-button-small opc-btn-primary">
+																<span>{l s='Apply'}</span>
+															</button>
+														</div>
+													</form>
+												</div>
+
+												{* The available highlighted vouchers for the customer*}
+												{if $displayVouchers}
+													<p class="cart_voucher_head">{l s='Available Coupons'}</p>
+													<div class="row avail_vouchers_block">
+														{foreach from=$displayVouchers key=key item=voucher name=availVoucher}
+															<div class="col-xs-12">
+																<p class="avail_voucher_name">
+																<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'} -</span>&nbsp;{$voucher.name}
+																</p>
+																{if not $smarty.foreach.availVoucher.last}
+																	<hr class="seperator">
+																{/if}
+															</div>
+														{/foreach}
+													</div>
+												{/if}
+											</div>
+										{/if}
+										{* End Voucher Block *}
+									{/block}
+									{block name='displayCartRightColumn'}
+										{hook h="displayCartRightColumn"}
+									{/block}
+								</div>
+							{/block}
+						{else}
+							{capture name=path}{l s='Your booking cart'}{/capture}
+							{block name='order_opc_heading'}
+								<h2 class="page-heading">{l s='Your booking cart'}</h2>
+							{/block}
+							{block name='errors'}
+								{include file="$tpl_dir./errors.tpl"}
+							{/block}
+
+							<p class="alert alert-warning">{l s='You have not added any rooms or products to your cart yet.'}</p>
+						{/if}
+						{block name='order_opc_js_vars'}
+							{strip}
+								{addJsDef imgDir=$img_dir}
+								{addJsDef authenticationUrl=$link->getPageLink("authentication", true)|escape:'quotes':'UTF-8'}
+								{addJsDef orderOpcUrl=$link->getPageLink("order-opc", true)|escape:'quotes':'UTF-8'}
+								{addJsDef guestTrackingUrl=$link->getPageLink("guest-tracking", true)|escape:'quotes':'UTF-8'}
+								{addJsDef addressUrl=$link->getPageLink("address", true, NULL, "back={$back_order_page}")|escape:'quotes':'UTF-8'}
+								{addJsDef orderProcess='order-opc'}
+								{addJsDef guestCheckoutEnabled=$PS_GUEST_CHECKOUT_ENABLED|intval}
+								{addJsDef displayPrice=$priceDisplay}
+								{addJsDef taxEnabled=$use_taxes}
+								{addJsDef conditionEnabled=$conditions|intval}
+								{addJsDef errorCarrier=$errorCarrier|@addcslashes:'\''}
+								{addJsDef errorTOS=$errorTOS|@addcslashes:'\''}
+								{addJsDef checkedCarrier=$checked|intval}
+								{addJsDef addresses=array()}
+								{addJsDef isVirtualCart=$isVirtualCart|intval}
+								{addJsDef isPaymentStep=$isPaymentStep|intval}
+								{addJsDef PS_REGISTRATION_PROCESS_TYPE=$PS_REGISTRATION_PROCESS_TYPE|intval}
+								{addJsDefL name=txtWithTax}{l s='(tax incl.)' js=1}{/addJsDefL}
+								{addJsDefL name=txtWithoutTax}{l s='(tax excl.)' js=1}{/addJsDefL}
+								{addJsDefL name=txtHasBeenSelected}{l s='has been selected' js=1}{/addJsDefL}
+								{addJsDefL name=txtNoCarrierIsSelected}{l s='No carrier has been selected' js=1}{/addJsDefL}
+								{addJsDefL name=txtNoCarrierIsNeeded}{l s='No carrier is needed for this order' js=1}{/addJsDefL}
+								{addJsDefL name=txtConditionsIsNotNeeded}{l s='You do not need to accept the Terms of Service for this order.' js=1}{/addJsDefL}
+								{addJsDefL name=txtTOSIsAccepted}{l s='The service terms have been accepted' js=1}{/addJsDefL}
+								{addJsDefL name=txtTOSIsNotAccepted}{l s='The service terms have not been accepted' js=1}{/addJsDefL}
+								{addJsDefL name=txtThereis}{l s='There is' js=1}{/addJsDefL}
+								{addJsDefL name=txtErrors}{l s='Error(s)' js=1}{/addJsDefL}
+								{addJsDefL name=txtDeliveryAddress}{l s='Delivery address' js=1}{/addJsDefL}
+								{addJsDefL name=txtInvoiceAddress}{l s='Invoice address' js=1}{/addJsDefL}
+								{addJsDefL name=txtModifyMyAddress}{l s='Modify my address' js=1}{/addJsDefL}
+								{addJsDefL name=txtInstantCheckout}{l s='Instant checkout' js=1}{/addJsDefL}
+								{addJsDefL name=txtSelectAnAddressFirst}{l s='Please start by selecting an address.' js=1}{/addJsDefL}
+								{addJsDefL name=txtFree}{l s='Free' js=1}{/addJsDefL}
+
+								{capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
+								{capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
+								{addJsDef addressUrl=$smarty.capture.addressUrl}
+								{capture}{'&multi-shipping=1'|urlencode}{/capture}
+								{addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
+								{capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
+								{addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
+								{addJsDef opc=$opc|boolval}
+								{capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
+								{addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+								{capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
+								{addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+								{capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
+								{addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+								{addJsDefL name=txtExtraDemandSucc}{l s='Updated Successfully' js=1}{/addJsDefL}
+								{addJsDefL name=txtMaxQuantityAdded}{l s='Maximum quantity of service added' js=1}{/addJsDefL}
+								{addJsDefL name=txtExtraDemandErr}{l s='Some error occurred while updating demands' js=1}{/addJsDefL}
+							{/strip}
+						{/block}
+					{/if}
+				</div>
+			</section>
+		</div>
+	</section>
+{/block}

--- a/themes/hotel-reservation-theme/order-payment-advanced.tpl
+++ b/themes/hotel-reservation-theme/order-payment-advanced.tpl
@@ -1,1 +1,156 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{if !isset($addresses_style)}
+    {$addresses_style.company = 'address_company'}
+    {$addresses_style.firstname = 'address_name'}
+    {$addresses_style.lastname = 'address_name'}
+    {$addresses_style.address1 = 'address_address1'}
+    {$addresses_style.address2 = 'address_address2'}
+    {$addresses_style.city = 'address_city'}
+    {$addresses_style.country = 'address_country'}
+    {$addresses_style.phone = 'address_phone'}
+    {$addresses_style.phone_mobile = 'address_phone_mobile'}
+    {$addresses_style.alias = 'address_title'}
+{/if}
+{assign var='have_non_virtual_products' value=false}
+{foreach $products as $product}
+    {if $product.is_virtual == 0}
+        {assign var='have_non_virtual_products' value=true}
+        {break}
+    {/if}
+{/foreach}
+
+{addJsDefL name=txtProduct}{l s='Product' js=1}{/addJsDefL}
+{addJsDefL name=txtProducts}{l s='Products' js=1}{/addJsDefL}
+{capture name=path}{l s='Your shopping cart'}{/capture}
+
+{if $productNumber == 0}
+<p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
+{elseif $PS_CATALOG_MODE}
+<p class="alert alert-warning">{l s='This store has not accepted your new order.'}</p>
+{else}
+    <p id="emptyCartWarning" class="alert alert-warning unvisible">{l s='Your shopping cart is empty.'}</p>
+    <h2>{l s='Payment Options'}</h2>
+    <!-- HOOK_ADVANCED_PAYMENT -->
+    {block name='advancedPaymentOptions'}
+        <div id="HOOK_ADVANCED_PAYMENT">
+            <div class="row">
+            <!-- Should get a collection of "PaymentOption" object -->
+            {assign var='adv_payment_empty' value=true}
+            {foreach from=$HOOK_ADVANCED_PAYMENT item=pay_option key=key}
+                {if $pay_option}
+                    {assign var='adv_payment_empty' value=false}
+                {/if}
+            {/foreach}
+            {if $HOOK_ADVANCED_PAYMENT && !$adv_payment_empty}
+                {foreach $HOOK_ADVANCED_PAYMENT as $advanced_payment_opt_list}
+                    {foreach $advanced_payment_opt_list as $paymentOption}
+                        <div class="col-xs-12 col-md-6">
+                            <p class="payment_module pointer-box">
+                                <a class="payment_module_adv">
+                                    <img class="payment_option_logo" src="{$paymentOption->getLogo()}"/>
+                                    <span class="payment_option_cta">
+                                        {$paymentOption->getCallToActionText()}
+                                    </span>
+                                    <span class="pull-right payment_option_selected">
+                                        <i class="icon-check"></i>
+                                    </span>
+                                </a>
+
+                            </p>
+                            <div class="payment_option_form">
+                                {if $paymentOption->getForm()}
+                                    {$paymentOption->getForm()}
+                                {else}
+                                    <form method="{if $paymentOption->getMethod()}{$paymentOption->getMethod()}{else}POST{/if}" action="{$paymentOption->getAction()}">
+                                        {if $paymentOption->getInputs()}
+                                            {foreach from=$paymentOption->getInputs() item=value key=name}
+                                                <input type="hidden" name="{$name}" value="{$value}">
+                                            {/foreach}
+                                        {/if}
+                                    </form>
+                                {/if}
+                            </div>
+                        </div>
+                    {/foreach}
+                {/foreach}
+            </div>
+            {else}
+            <div class="col-xs-12 col-md-12">
+                <p class="alert alert-warning ">{l s='Unable to find any available payment option for your cart. Please contact us if the problem persists'}</p>
+            </div>
+            {/if}
+        </div>
+    {/block}
+    <!-- end HOOK_ADVANCED_PAYMENT -->
+
+    {if $opc}
+        <!-- Carrier -->
+        {block name='order_carrier_advanced'}
+            {include file="$tpl_dir./order-carrier-advanced.tpl"}
+        {/block}
+        <!-- END Carrier -->
+    {/if}
+
+    {if $is_logged AND !$is_guest}
+        {block name='order_address_advanced'}
+            {include file="$tpl_dir./order-address-advanced.tpl"}
+        {/block}
+    {elseif $opc}
+        <!-- Create account / Guest account / Login block -->
+        {block name='order_opc_new_account_advanced'}
+            {include file="$tpl_dir./order-opc-new-account-advanced.tpl"}
+        {/block}
+        <!-- END Create account / Guest account / Login block -->
+    {/if}
+
+    {block name='order_payment_advanced_terms_and_conditions'}
+        <!-- TNC -->
+        {if $conditions AND $cms_id}
+            {if $override_tos_display }
+                {$override_tos_display}
+            {else}
+                <div class="row">
+                    <div class="col-xs-12 col-md-12">
+                        <h2>{l s='Terms and Conditions'}</h2>
+                        <div class="box">
+                            <p class="checkbox">
+                                <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
+                                <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
+                                <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            {/if}
+        {/if}
+        <!-- end TNC -->
+    {/block}
+
+    {block name='shopping_cart_advanced'}
+        {include file="$tpl_dir./shopping-cart-advanced.tpl"}
+    {/block}
+{/if}

--- a/themes/hotel-reservation-theme/order-payment-classic.tpl
+++ b/themes/hotel-reservation-theme/order-payment-classic.tpl
@@ -1,1 +1,350 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+<div class="paiement_block">
+    {block name='order_opc_advanced_payment_option'}
+        {include file="$tpl_dir./order-opc-advanced-payment-option.tpl"}
+    {/block}
+
+    {block name='order_payment_classic_terms_and_conditions'}
+        <div id="tc_cont">
+            <p class="checkbox">
+                <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
+                <label for="cgv" id="tc_txt">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
+                <a id="tc_link" href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow" >{l s='(Read the Terms of Service)'}</a>
+            </p>
+        </div>
+    {/block}
+    <p class="block-small-header">{l s='PAYMENT RESOURCE'}</p>
+    {block name='displayPaymentTop'}
+        <div id="HOOK_TOP_PAYMENT">{$HOOK_TOP_PAYMENT}</div>
+    {/block}
+    {if $HOOK_PAYMENT}
+        {if !$opc}
+            {block name='order_payment_classic_cart_summary'}
+                <div id="order-detail-content" class="table_block table-responsive">
+                    <table id="cart_summary" class="table table-bordered">
+                        <thead>
+                        <tr>
+                            <th class="cart_product first_item">{l s='Product'}</th>
+                            <th class="cart_description item">{l s='Description'}</th>
+                            {if $PS_STOCK_MANAGEMENT}
+                                <th class="cart_availability item text-center">{l s='Availability'}</th>
+                            {/if}
+                            <th class="cart_unit item text-right">{l s='Unit price'}</th>
+                            <th class="cart_quantity item text-center">{l s='Qty'}</th>
+                            <th class="cart_total last_item text-right">{l s='Total'}</th>
+                        </tr>
+                        </thead>
+                        <tfoot>
+                        {if $use_taxes}
+                            {if $priceDisplay}
+                                <tr class="cart_total_price">
+                                    <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total products (tax excl.)'}{else}{l s='Total products'}{/if}</td>
+                                    <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
+                                </tr>
+                            {else}
+                                <tr class="cart_total_price">
+                                    <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total products (tax incl.)'}{else}{l s='Total products'}{/if}</td>
+                                    <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products_wt}</td>
+                                </tr>
+                            {/if}
+                        {else}
+                            <tr class="cart_total_price">
+                                <td colspan="4" class="text-right">{l s='Total products'}</td>
+                                <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
+                            </tr>
+                        {/if}
+                        <tr class="cart_total_voucher" {if $total_wrapping == 0}style="display:none"{/if}>
+                            <td colspan="4" class="text-right">
+                                {if $use_taxes}
+                                    {if $priceDisplay}
+                                        {if $display_tax_label}{l s='Total gift wrapping (tax excl.):'}{else}{l s='Total gift wrapping cost:'}{/if}
+                                    {else}
+                                        {if $display_tax_label}{l s='Total gift wrapping (tax incl.)'}{else}{l s='Total gift wrapping cost:'}{/if}
+                                    {/if}
+                                {else}
+                                    {l s='Total gift wrapping cost:'}
+                                {/if}
+                            </td>
+                            <td colspan="2" class="price-discount price" id="total_wrapping">
+                                {if $use_taxes}
+                                    {if $priceDisplay}
+                                        {displayPrice price=$total_wrapping_tax_exc}
+                                    {else}
+                                        {displayPrice price=$total_wrapping}
+                                    {/if}
+                                {else}
+                                    {displayPrice price=$total_wrapping_tax_exc}
+                                {/if}
+                            </td>
+                        </tr>
+                        {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
+                            <tr class="cart_total_delivery">
+                                <td colspan="4" class="text-right">{l s='Total shipping'}</td>
+                                <td colspan="2" class="price" id="total_shipping">{l s='Free Shipping!'}</td>
+                            </tr>
+                        {else}
+                            {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
+                                {if $priceDisplay}
+                                    <tr class="cart_total_delivery" {if $shippingCost <= 0} style="display:none"{/if}>
+                                        <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total shipping (tax excl.)'}{else}{l s='Total shipping'}{/if}</td>
+                                        <td colspan="2" class="price" id="total_shipping">{displayPrice price=$shippingCostTaxExc}</td>
+                                    </tr>
+                                {else}
+                                    <tr class="cart_total_delivery"{if $shippingCost <= 0} style="display:none"{/if}>
+                                        <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total shipping (tax incl.)'}{else}{l s='Total shipping'}{/if}</td>
+                                        <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$shippingCost}</td>
+                                    </tr>
+                                {/if}
+                            {else}
+                                <tr class="cart_total_delivery"{if $shippingCost <= 0} style="display:none"{/if}>
+                                    <td colspan="4" class="text-right">{l s='Total shipping'}</td>
+                                    <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$shippingCostTaxExc}</td>
+                                </tr>
+                            {/if}
+                        {/if}
+                        <tr class="cart_total_voucher" {if $total_discounts == 0}style="display:none"{/if}>
+                            <td colspan="4" class="text-right">
+                                {if $use_taxes}
+                                    {if $priceDisplay}
+                                        {if $display_tax_label && $show_taxes}{l s='Total vouchers (tax excl.)'}{else}{l s='Total vouchers'}{/if}
+                                    {else}
+                                        {if $display_tax_label && $show_taxes}{l s='Total vouchers (tax incl.)'}{else}{l s='Total vouchers'}{/if}
+                                    {/if}
+                                {else}
+                                    {l s='Total vouchers'}
+                                {/if}
+                            </td>
+                            <td colspan="2" class="price-discount price" id="total_discount">
+                                {if $use_taxes}
+                                    {if $priceDisplay}
+                                        {displayPrice price=$total_discounts_tax_exc*-1}
+                                    {else}
+                                        {displayPrice price=$total_discounts*-1}
+                                    {/if}
+                                {else}
+                                    {displayPrice price=$total_discounts_tax_exc*-1}
+                                {/if}
+                            </td>
+                        </tr>
+                        {if $use_taxes}
+                            {if $total_tax != 0 && $show_taxes}
+                                {if $priceDisplay != 0}
+                                    <tr class="cart_total_price">
+                                        <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total (tax excl.)'}{else}{l s='Total'}{/if}</td>
+                                        <td colspan="2" class="price" id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</td>
+                                    </tr>
+                                {/if}
+                                <tr class="cart_total_tax">
+                                    <td colspan="4" class="text-right">{l s='Tax'}</td>
+                                    <td colspan="2" class="price" id="total_tax" >{displayPrice price=$total_tax}</td>
+                                </tr>
+                            {/if}
+                            <tr class="cart_total_price">
+                                <td colspan="4" class="total_price_container text-right"><span>{l s='Total'}</span></td>
+                                <td colspan="2" class="price" id="total_price_container">
+                                    <span id="total_price" data-selenium-total-price="{$total_price}">{displayPrice price=$total_price}</span>
+                                </td>
+                            </tr>
+                        {else}
+                            <tr class="cart_total_price">
+                                {if $voucherAllowed}
+                                    <td colspan="2" id="cart_voucher" class="cart_voucher">
+                                        <div id="cart_voucher" class="table_block">
+                                            {if isset($errors_discount) && $errors_discount}
+                                                <ul class="alert alert-danger">
+                                                    {foreach from=$errors_discount key=k item=error}
+                                                        <li>{$error|escape:'html':'UTF-8'}</li>
+                                                    {/foreach}
+                                                </ul>
+                                            {/if}
+                                            {if $voucherAllowed}
+                                                <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                                                    <fieldset>
+                                                        <h4>{l s='Vouchers'}</h4>
+                                                        <input type="text" id="discount_name" class="form-control" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                                                        <input type="hidden" name="submitDiscount" />
+                                                        <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='ok'}</span></button>
+                                                        {if $displayVouchers}
+                                                            <p id="title" class="title_offers">{l s='Take advantage of our offers:'}</p>
+                                                            <div id="display_cart_vouchers">
+                                                                {foreach from=$displayVouchers item=voucher}
+                                                                    <span onclick="$('#discount_name').val('{$voucher.name}');return false;" class="voucher_name">{$voucher.name}</span> - {$voucher.description} <br />
+                                                                {/foreach}
+                                                            </div>
+                                                        {/if}
+                                                    </fieldset>
+                                                </form>
+                                            {/if}
+                                        </div>
+                                    </td>
+                                {/if}
+                                <td colspan="{if !$voucherAllowed}4{else}2{/if}" class="text-right total_price_container">
+                                    <span>{l s='Total'}</span>
+                                </td>
+                                <td colspan="2" class="price total_price_container" id="total_price_container">
+                                    <span id="total_price" data-selenium-total-price="{$total_price_without_tax}">{displayPrice price=$total_price_without_tax}</span>
+                                </td>
+                            </tr>
+                        {/if}
+                        </tfoot>
+
+                        <tbody>
+                        {foreach from=$products item=product name=productLoop}
+                            {assign var='productId' value=$product.id_product}
+                            {assign var='productAttributeId' value=$product.id_product_attribute}
+                            {assign var='quantityDisplayed' value=0}
+                            {assign var='cannotModify' value=1}
+                            {assign var='odd' value=$product@iteration%2}
+                            {assign var='noDeleteButton' value=1}
+
+                            {* Display the product line *}
+                            {block name='shopping_cart_product_line'}
+                                {include file="$tpl_dir./shopping-cart-product-line.tpl"}
+                            {/block}
+
+                            {* Then the customized datas ones*}
+                            {if isset($customizedDatas.$productId.$productAttributeId)}
+                                {foreach from=$customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] key='id_customization' item='customization'}
+                                    <tr id="product_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}" class="alternate_item cart_item">
+                                        <td colspan="4">
+                                            {foreach from=$customization.datas key='type' item='datas'}
+                                                {if $type == $CUSTOMIZE_FILE}
+                                                    <div class="customizationUploaded">
+                                                        <ul class="customizationUploaded">
+                                                            {foreach from=$datas item='picture'}
+                                                                <li>
+                                                                    <img src="{$pic_dir}{$picture.value}_small" alt="" class="customizationUploaded" />
+                                                                </li>
+                                                            {/foreach}
+                                                        </ul>
+                                                    </div>
+                                                {elseif $type == $CUSTOMIZE_TEXTFIELD}
+                                                    <ul class="typedText">
+                                                        {foreach from=$datas item='textField' name='typedText'}
+                                                            <li>
+                                                                {if $textField.name}
+                                                                    {l s='%s:' sprintf=$textField.name}
+                                                                {else}
+                                                                    {l s='Text #%s:' sprintf=$smarty.foreach.typedText.index+1}
+                                                                {/if}
+                                                                {$textField.value}
+                                                            </li>
+                                                        {/foreach}
+                                                    </ul>
+                                                {/if}
+                                            {/foreach}
+                                        </td>
+                                        <td class="cart_quantity text-center">
+                                            {$customization.quantity}
+                                        </td>
+                                        <td class="cart_total"></td>
+                                    </tr>
+                                    {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.quantity}
+                                {/foreach}
+                                {* If it exists also some uncustomized products *}
+                                {if $product.quantity-$quantityDisplayed > 0}{block name='shopping_cart_product_line'}{include file="$tpl_dir./shopping-cart-product-line.tpl"}{/block}{/if}
+                            {/if}
+                        {/foreach}
+                        {assign var='last_was_odd' value=$product@iteration%2}
+                        {foreach $gift_products as $product}
+                            {assign var='productId' value=$product.id_product}
+                            {assign var='productAttributeId' value=$product.id_product_attribute}
+                            {assign var='quantityDisplayed' value=0}
+                            {assign var='odd' value=($product@iteration+$last_was_odd)%2}
+                            {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId)}
+                            {assign var='cannotModify' value=1}
+                            {* Display the gift product line *}
+                            {block name='shopping_cart_product_line'}
+                                {include file="./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first}
+                            {/block}
+                        {/foreach}
+                        </tbody>
+
+                        {if count($discounts)}
+                            <tbody>
+                            {foreach from=$discounts item=discount name=discountLoop}
+                                {if (float)$discount.value_real == 0}
+                                    {continue}
+                                {/if}
+                                <tr class="cart_discount {if $smarty.foreach.discountLoop.last}last_item{elseif $smarty.foreach.discountLoop.first}first_item{else}item{/if}" id="cart_discount_{$discount.id_discount}">
+                                    <td class="cart_discount_name" colspan="{if $PS_STOCK_MANAGEMENT}3{else}2{/if}">{$discount.name}</td>
+                                    <td class="cart_discount_price">
+                                                        <span class="price-discount">
+                                                            {if $discount.value_real > 0}
+                                                                {if !$priceDisplay}
+                                                                    {displayPrice price=$discount.value_real*-1}
+                                                                {else}
+                                                                    {displayPrice price=$discount.value_tax_exc*-1}
+                                                                {/if}
+                                                            {/if}
+                                                        </span>
+                                    </td>
+                                    <td class="cart_discount_delete">1</td>
+                                    <td class="cart_discount_price">
+                                                        <span class="price-discount">
+                                                            {if $discount.value_real > 0}
+                                                                {if !$priceDisplay}
+                                                                    {displayPrice price=$discount.value_real*-1}
+                                                                {else}
+                                                                    {displayPrice price=$discount.value_tax_exc*-1}
+                                                                {/if}
+                                                            {/if}
+                                                        </span>
+                                    </td>
+                                </tr>
+                            {/foreach}
+                            </tbody>
+                        {/if}
+                    </table>
+                </div> <!-- end order-detail-content -->
+            {/block}
+        {/if}
+        {if $opc}
+            <div id="opc_payment_methods-content">
+        {/if}
+        {block name='displayPayment'}
+            <div id="HOOK_PAYMENT">
+                {$HOOK_PAYMENT}
+            </div>
+        {/block}
+        {if $opc}
+            </div> <!-- end opc_payment_methods-content -->
+        {/if}
+    {else}
+        <p class="alert alert-warning">{l s='No payment modules have been installed.'}</p>
+    {/if}
+    {if !$opc}
+    <p class="cart_navigation clearfix">
+        <a href="{$link->getPageLink('order', true, NULL, "step=2")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+            <i class="icon-chevron-left"></i>
+            {l s='Continue shopping'}
+        </a>
+    </p>
+    {else}
+</div> <!-- end opc_payment_methods -->
+{/if}
+</div> <!-- end HOOK_TOP_PAYMENT -->

--- a/themes/hotel-reservation-theme/order-payment.tpl
+++ b/themes/hotel-reservation-theme/order-payment.tpl
@@ -1,1 +1,59 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{if !$opc}
+	{addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
+	{addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
+	{capture name=path}{l s='Your payment method'}{/capture}
+	<h1 class="page-heading">{l s='Please choose your payment method'}
+		{if !isset($empty) && !$PS_CATALOG_MODE}
+			<span class="heading-counter">{l s='Your shopping cart contains:'}
+				<span id="summary_products_quantity">{$productNumber} {if $productNumber == 1}{l s='product'}{else}{l s='products'}{/if}</span>
+			</span>
+		{/if}
+	</h1>
+{/if}
+
+{if !$opc}
+	{assign var='current_step' value='payment'}
+	{block name='order_steps'}
+		{include file="$tpl_dir./order-steps.tpl"}
+	{/block}
+	{block name='errors'}
+		{include file="$tpl_dir./errors.tpl"}
+	{/block}
+{else}
+	<div id="opc_payment_methods" class="opc-main-block">
+		<div id="opc_payment_methods-overlay" class="opc-overlay" style="display: none;"></div>
+{/if}
+{if $advanced_payment_api}
+	{block name='order_payment_advanced'}
+		{include file="$tpl_dir./order-payment-advanced.tpl"}
+	{/block}
+{else}
+	{block name='order_payment_classic'}
+		{include file = "$tpl_dir./order-payment-classic.tpl"}
+	{/block}
+{/if}

--- a/themes/hotel-reservation-theme/order-steps.tpl
+++ b/themes/hotel-reservation-theme/order-steps.tpl
@@ -1,3 +1,79 @@
-<nav class="order-steps order-steps--inquiry">
-    {include file='_partials/checkout-inquiry-message.tpl'}
-</nav>
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{* Assign a value to 'current_step' to display current style *}
+{capture name="url_back"}
+{if isset($back) && $back}back={$back}{/if}
+{/capture}
+
+{if !isset($multi_shipping)}
+	{assign var='multi_shipping' value='0'}
+{/if}
+
+{if !$opc && ((!isset($back) || empty($back)) || (isset($back) && preg_match("/[&?]step=/", $back)))}
+<!-- Steps -->
+<ul class="step clearfix" id="order_step">
+	<li class="{if $current_step=='summary'}step_current {elseif $current_step=='login'}step_done_last step_done{else}{if $current_step=='payment' || $current_step=='shipping' || $current_step=='address' || $current_step=='login'}step_done{else}step_todo{/if}{/if} first">
+		{if $current_step=='payment' || $current_step=='shipping' || $current_step=='address' || $current_step=='login'}
+		<a href="{$link->getPageLink('order', true)}">
+			<em>01.</em> {l s='Summary'}
+		</a>
+		{else}
+			<span><em>01.</em> {l s='Summary'}</span>
+		{/if}
+	</li>
+	<li class="{if $current_step=='login'}step_current{elseif $current_step=='address'}step_done step_done_last{else}{if $current_step=='payment' || $current_step=='shipping' || $current_step=='address'}step_done{else}step_todo{/if}{/if} second">
+		{if $current_step=='payment' || $current_step=='shipping' || $current_step=='address'}
+		<a href="{$link->getPageLink('order', true, NULL, "{$smarty.capture.url_back}&step=1{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}">
+			<em>02.</em> {l s='Sign in'}
+		</a>
+		{else}
+			<span><em>02.</em> {l s='Sign in'}</span>
+		{/if}
+	</li>
+	<li class="{if $current_step=='address'}step_current{elseif $current_step=='shipping'}step_done step_done_last{else}{if $current_step=='payment' || $current_step=='shipping'}step_done{else}step_todo{/if}{/if} third">
+		{if $current_step=='payment' || $current_step=='shipping'}
+		<a href="{$link->getPageLink('order', true, NULL, "{$smarty.capture.url_back}&step=1{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}">
+			<em>03.</em> {l s='Address'}
+		</a>
+		{else}
+			<span><em>03.</em> {l s='Address'}</span>
+		{/if}
+	</li>
+	<li class="{if $current_step=='shipping'}step_current{else}{if $current_step=='payment'}step_done step_done_last{else}step_todo{/if}{/if} four">
+		{if $current_step=='payment'}
+		<a href="{$link->getPageLink('order', true, NULL, "{$smarty.capture.url_back}&step=2{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}">
+			<em>04.</em> {l s='Shipping'}
+		</a>
+		{else}
+			<span><em>04.</em> {l s='Shipping'}</span>
+		{/if}
+	</li>
+	<li id="step_end" class="{if $current_step=='payment'}step_current{else}step_todo{/if} last">
+		<span><em>05.</em> {l s='Payment'}</span>
+	</li>
+</ul>
+<!-- /Steps -->
+{/if}

--- a/themes/hotel-reservation-theme/shopping-cart-advanced.tpl
+++ b/themes/hotel-reservation-theme/shopping-cart-advanced.tpl
@@ -1,1 +1,387 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+<h2>{l s='Cart Summary'}</h2>
+{assign var='total_discounts_num' value="{if $total_discounts != 0}1{else}0{/if}"}
+{assign var='use_show_taxes' value="{if $use_taxes && $show_taxes}2{else}0{/if}"}
+{assign var='total_wrapping_taxes_num' value="{if $total_wrapping != 0}1{else}0{/if}"}
+{* eu-legal *}
+{block name='displayBeforeShoppingCartBlock'}
+    {hook h="displayBeforeShoppingCartBlock"}
+{/block}
+{block name='shopping_cart_detail'}
+    <div id="order-detail-content" class="table_block table-responsive">
+        <table id="cart_summary" class="table table-bordered {if $PS_STOCK_MANAGEMENT}stock-management-on{else}stock-management-off{/if}">
+            <thead>
+            <tr>
+                <th class="cart_product first_item">{l s='Product'}</th>
+                <th class="cart_description item">{l s='Description'}</th>
+                {if $PS_STOCK_MANAGEMENT}
+                    {assign var='col_span_subtotal' value='3'}
+                    {assign var='col_span_total' value='7'}
+                    <th class="cart_avail item text-center">{l s='Availability'}</th>
+                {else}
+                    {assign var='col_span_subtotal' value='2'}
+                    {assign var='col_span_total' value='6'}
+                {/if}
+                <th class="cart_unit item text-right">{l s='Unit price'}</th>
+                <th class="cart_quantity item text-center">{l s='Qty'}</th>
+                <th colspan="{$col_span_subtotal}" class="cart_total item text-right">{l s='Total'}</th>
+            </tr>
+            </thead>
+            <tfoot>
+            {assign var='rowspan_total' value=2+$total_discounts_num+$total_wrapping_taxes_num}
+
+            {if $use_taxes && $show_taxes && $total_tax != 0}
+                {assign var='rowspan_total' value=$rowspan_total+1}
+            {/if}
+
+            {if $priceDisplay != 0}
+                {assign var='rowspan_total' value=$rowspan_total+1}
+            {/if}
+
+            {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
+                {assign var='rowspan_total' value=$rowspan_total+1}
+            {else}
+                {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
+                    {if $priceDisplay && $total_shipping_tax_exc > 0}
+                        {assign var='rowspan_total' value=$rowspan_total+1}
+                    {elseif $total_shipping > 0}
+                        {assign var='rowspan_total' value=$rowspan_total+1}
+                    {/if}
+                {elseif $total_shipping_tax_exc > 0}
+                    {assign var='rowspan_total' value=$rowspan_total+1}
+                {/if}
+            {/if}
+
+            {if $use_taxes}
+                {if $priceDisplay}
+                    <tr class="cart_total_price">
+                        <td rowspan="{$rowspan_total}" colspan="3" id="cart_voucher" class="cart_voucher">
+                            {if $voucherAllowed}
+                                <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                                    <fieldset>
+                                        <h4>{l s='Vouchers'}</h4>
+                                        <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                                        <input type="hidden" name="submitDiscount" />
+                                        <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
+                                    </fieldset>
+                                </form>
+                                {if $displayVouchers}
+                                    <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
+                                    <div id="display_cart_vouchers">
+                                        {foreach $displayVouchers as $voucher}
+                                            {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
+                                        {/foreach}
+                                    </div>
+                                {/if}
+                            {/if}
+                        </td>
+                        <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax excl.)'}{else}{l s='Total products'}{/if}</td>
+                        <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
+                    </tr>
+                {else}
+                    <tr class="cart_total_price">
+                        <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
+                            {if $voucherAllowed}
+                                <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                                    <fieldset>
+                                        <h4>{l s='Vouchers'}</h4>
+                                        <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                                        <input type="hidden" name="submitDiscount" />
+                                        <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
+                                    </fieldset>
+                                </form>
+                                {if $displayVouchers}
+                                    <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
+                                    <div id="display_cart_vouchers">
+                                        {foreach $displayVouchers as $voucher}
+                                            {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
+                                        {/foreach}
+                                    </div>
+                                {/if}
+                            {/if}
+                        </td>
+                        <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax incl.)'}{else}{l s='Total products'}{/if}</td>
+                        <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products_wt}</td>
+                    </tr>
+                {/if}
+            {else}
+                <tr class="cart_total_price">
+                    <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
+                        {if $voucherAllowed}
+                            <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                                <fieldset>
+                                    <h4>{l s='Vouchers'}</h4>
+                                    <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                                    <input type="hidden" name="submitDiscount" />
+                                    <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small">
+                                        <span>{l s='OK'}</span>
+                                    </button>
+                                </fieldset>
+                            </form>
+                            {if $displayVouchers}
+                                <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
+                                <div id="display_cart_vouchers">
+                                    {foreach $displayVouchers as $voucher}
+                                        {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
+                                    {/foreach}
+                                </div>
+                            {/if}
+                        {/if}
+                    </td>
+                    <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total products'}</td>
+                    <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
+                </tr>
+            {/if}
+            <tr {if $total_wrapping == 0} style="display: none;"{/if}>
+                <td colspan="3" class="text-right">
+                    {if $use_taxes}
+                        {if $display_tax_label}{l s='Total gift wrapping (tax incl.)'}{else}{l s='Total gift-wrapping cost'}{/if}
+                    {else}
+                        {l s='Total gift-wrapping cost'}
+                    {/if}
+                </td>
+                <td colspan="2" class="price-discount price" id="total_wrapping">
+                    {if $use_taxes}
+                        {if $priceDisplay}
+                            {displayPrice price=$total_wrapping_tax_exc}
+                        {else}
+                            {displayPrice price=$total_wrapping}
+                        {/if}
+                    {else}
+                        {displayPrice price=$total_wrapping_tax_exc}
+                    {/if}
+                </td>
+            </tr>
+            {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart)}
+                <tr class="cart_total_delivery{if !$opc && (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
+                    <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
+                    <td colspan="2" class="price" id="total_shipping">{l s='Free shipping!'}</td>
+                </tr>
+            {else}
+                {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
+                    {if $priceDisplay}
+                        <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
+                            <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax excl.)'}{else}{l s='Total shipping'}{/if}</td>
+                            <td colspan="2" class="price" id="total_shipping">{displayPrice price=$total_shipping_tax_exc}</td>
+                        </tr>
+                    {else}
+                        <tr class="cart_total_delivery{if $total_shipping <= 0} unvisible{/if}">
+                            <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax incl.)'}{else}{l s='Total shipping'}{/if}</td>
+                            <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping}</td>
+                        </tr>
+                    {/if}
+                {else}
+                    <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
+                        <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
+                        <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping_tax_exc}</td>
+                    </tr>
+                {/if}
+            {/if}
+            <tr class="cart_total_voucher{if $total_discounts == 0} unvisible{/if}">
+                <td colspan="{$col_span_subtotal}" class="text-right">
+                    {if $display_tax_label}
+                        {if $use_taxes && $priceDisplay == 0}
+                            {l s='Total vouchers (tax incl.)'}
+                        {else}
+                            {l s='Total vouchers (tax excl.)'}
+                        {/if}
+                    {else}
+                        {l s='Total vouchers'}
+                    {/if}
+                </td>
+                <td colspan="2" class="price-discount price" id="total_discount">
+                    {if $use_taxes && $priceDisplay == 0}
+                        {assign var='total_discounts_negative' value=$total_discounts * -1}
+                    {else}
+                        {assign var='total_discounts_negative' value=$total_discounts_tax_exc * -1}
+                    {/if}
+                    {displayPrice price=$total_discounts_negative}
+                </td>
+            </tr>
+            {if $use_taxes && $show_taxes && $total_tax != 0 }
+                {if $priceDisplay != 0}
+                    <tr class="cart_total_price">
+                        <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total (tax excl.)'}{else}{l s='Total'}{/if}</td>
+                        <td colspan="2" class="price" id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</td>
+                    </tr>
+                {/if}
+                <tr class="cart_total_tax">
+                    <td colspan="{$col_span_subtotal}" class="text-right">{l s='Tax'}</td>
+                    <td colspan="2" class="price" id="total_tax">{displayPrice price=$total_tax}</td>
+                </tr>
+            {/if}
+            <tr class="cart_total_price">
+                <td colspan="{$col_span_subtotal}" class="total_price_container text-right">
+                    <span>{l s='Total'}</span>
+                    {block name='displayCartTotalPriceLabel'}
+                        <div class="hookDisplayProductPriceBlock-price">
+                            {hook h="displayCartTotalPriceLabel"}
+                        </div>
+                    {/block}
+                </td>
+                {if $use_taxes}
+                    <td colspan="2" class="price" id="total_price_container">
+                        <span id="total_price">{displayPrice price=$total_price}</span>
+                    </td>
+                {else}
+                    <td colspan="2" class="price" id="total_price_container">
+                        <span id="total_price">{displayPrice price=$total_price_without_tax}</span>
+                    </td>
+                {/if}
+            </tr>
+            {block name='displayAfterShoppingCartBlock'}
+                {hook h="displayAfterShoppingCartBlock" colspan_total=$col_span_total}
+            {/block}
+            </tfoot>
+            <tbody>
+            {assign var='odd' value=0}
+            {assign var='have_non_virtual_products' value=false}
+            {foreach $products as $product}
+                {if $product.is_virtual == 0}
+                    {assign var='have_non_virtual_products' value=true}
+                {/if}
+                {assign var='productId' value=$product.id_product}
+                {assign var='productAttributeId' value=$product.id_product_attribute}
+                {assign var='quantityDisplayed' value=0}
+                {assign var='odd' value=($odd+1)%2}
+                {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId) || count($gift_products)}
+                {* Display the product line *}
+                {block name='shopping_cart_product_line'}
+                    {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first noDeleteButton=0 cannotModify=0}
+                {/block}
+                {* Then the customized datas ones*}
+                {if isset($customizedDatas.$productId.$productAttributeId)}
+                    {foreach $customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] as $id_customization=>$customization}
+                        <tr
+                                id="product_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
+                                class="product_customization_for_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}{if $odd} odd{else} even{/if} customization alternate_item {if $product@last && $customization@last && !count($gift_products)}last_item{/if}">
+                            <td></td>
+                            <td colspan="3">
+                                {foreach $customization.datas as $type => $custom_data}
+                                    {if $type == $CUSTOMIZE_FILE}
+                                        <div class="customizationUploaded">
+                                            <ul class="customizationUploaded">
+                                                {foreach $custom_data as $picture}
+                                                    <li><img src="{$pic_dir}{$picture.value}_small" alt="" class="customizationUploaded" /></li>
+                                                {/foreach}
+                                            </ul>
+                                        </div>
+                                    {elseif $type == $CUSTOMIZE_TEXTFIELD}
+                                        <ul class="typedText">
+                                            {foreach $custom_data as $textField}
+                                                <li>
+                                                    {if $textField.name}
+                                                        {$textField.name}
+                                                    {else}
+                                                        {l s='Text #'}{$textField@index+1}
+                                                    {/if}
+                                                    : {$textField.value}
+                                                </li>
+                                            {/foreach}
+                                        </ul>
+                                    {/if}
+                                {/foreach}
+                            </td>
+                            <td class="cart_quantity" colspan="1">
+                                <span>{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}</span>
+                            </td>
+
+                            <td>
+                            </td>
+                        </tr>
+                        {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.quantity}
+                    {/foreach}
+
+                    {* If it exists also some uncustomized products *}
+                    {if $product.quantity-$quantityDisplayed > 0}{include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first noDeleteButton=0 cannotModify=0}{/if}
+                {/if}
+            {/foreach}
+            {assign var='last_was_odd' value=$product@iteration%2}
+            {foreach $gift_products as $product}
+                {assign var='productId' value=$product.id_product}
+                {assign var='productAttributeId' value=$product.id_product_attribute}
+                {assign var='quantityDisplayed' value=0}
+                {assign var='odd' value=($product@iteration+$last_was_odd)%2}
+                {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId)}
+                {assign var='cannotModify' value=1}
+                {* Display the gift product line *}
+                {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first noDeleteButton=0 cannotModify=0}
+            {/foreach}
+            </tbody>
+            {if sizeof($discounts)}
+                <tbody>
+                {foreach $discounts as $discount}
+                    {if (float)$discount.value_real == 0}
+                        {continue}
+                    {/if}
+                    <tr class="cart_discount {if $discount@last}last_item{elseif $discount@first}first_item{else}item{/if}" id="cart_discount_{$discount.id_discount}">
+                        <td class="cart_discount_name" colspan="{if $PS_STOCK_MANAGEMENT}3{else}2{/if}">{$discount.name}</td>
+                        <td class="cart_discount_price">
+                                    <span class="price-discount">
+                                    {if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}
+                                    </span>
+                        </td>
+                        <td class="cart_discount_delete">1</td>
+                        <td class="price_discount_del text-center">
+                            {if strlen($discount.code)}
+                                <a
+                                        href="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}?deleteDiscount={$discount.id_discount}"
+                                        class="price_discount_delete"
+                                        title="{l s='Delete'}">
+                                    <i class="icon-trash"></i>
+                                </a>
+                            {/if}
+                        </td>
+                        <td class="cart_discount_price">
+                            <span class="price-discount price">{if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}</span>
+                        </td>
+                    </tr>
+                {/foreach}
+                </tbody>
+            {/if}
+        </table>
+    </div> <!-- end order-detail-content -->
+{/block}
+
+
+<p class="cart_navigation clearfix">
+
+    {if $opc}
+        {assign var='back_link' value=$link->getPageLink('index')}
+    {else}
+        {assign var='back_link' value=$link->getPageLink('order', true, NULL, "step=2")}
+    {/if}
+    <a href="{$back_link|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+        <i class="icon-chevron-left"></i>
+        {l s='Continue shopping'}
+    </a>
+    <button data-show-if-js="" style="" id="confirmOrder" type="button" class="button btn btn-default standard-checkout button-medium"><span>{l s='Order With Obligation To Pay'}</span></button>
+</p>
+
+{strip}
+{addJsDef deliveryAddress=$cart->id_address_delivery|intval}
+{/strip}

--- a/themes/hotel-reservation-theme/shopping-cart-detail.tpl
+++ b/themes/hotel-reservation-theme/shopping-cart-detail.tpl
@@ -1,1 +1,406 @@
-{include file='_partials/checkout-inquiry-message.tpl'}
+{*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License version 3.0
+* that is bundled with this package in the file LICENSE.md
+* It is also available through the world-wide-web at this URL:
+* https://opensource.org/license/osl-3-0-php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to support@qloapps.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade this module to a newer
+* versions in the future. If you wish to customize this module for your needs
+* please refer to https://store.webkul.com/customisation-guidelines for more information.
+*
+* @author Webkul IN
+* @copyright Since 2010 Webkul
+* @license https://opensource.org/license/osl-3-0-php Open Software License version 3.0
+*}
+
+<div class="order-detail-content">
+    {if isset($cart_htl_data) && $cart_htl_data}
+        {block name='shopping_cart_heading'}
+            <p class="cart_section_title">{l s='rooms information'}</p>
+        {/block}
+        {foreach from=$cart_htl_data key=data_k item=data_v}
+            {foreach from=$data_v['date_diff'] key=rm_k item=rm_v}
+                <div class="row cart_product_line">
+                    <div class="col-sm-2 product-img-block">
+                        {block name='shopping_cart_room_type_cover_image'}
+                            <p>
+                                <a href="{$link->getProductLink($data_v['id_product'])}">
+                                    <img src="{$data_v['cover_img']}" class="img-responsive" />
+                                </a>
+                            </p>
+                            <p class="room_remove_block">
+                                <a class="cart_room_delete" href="{$rm_v['link']}" data-id_product="{$data_v['id_product']}" data-date_from="{$rm_v['data_form']}" data-date_to="{$rm_v['data_to']}" data-qty="{$rm_v['num_rm']}"><i class="icon-trash"></i> &nbsp;{l s='Remove'}</a>
+                            </p>
+                            {block name='displayCartRoomImageAfter'}
+                                {hook h='displayCartRoomImageAfter' id_product=$data_v['id_product']}
+                            {/block}
+                        {/block}
+                    </div>
+                    <div class="col-sm-10">
+                        <div class="room-info-container">
+                            {block name='shopping_cart_room_type_cover_image_mobile'}
+                                <div class="product-xs-img">
+                                    <a href="{$link->getProductLink($data_v['id_product'])}">
+                                        <img src="{$data_v['cover_img']}" class="img-responsive" />
+                                    </a>
+                                </div>
+                            {/block}
+                            {block name='shopping_cart_room_detail'}
+                                <div class="product-xs-info">
+                                    {block name='shopping_cart_room_type_name'}
+                                        <p class="product-name">
+                                            <a href="{$link->getProductLink($data_v['id_product'])}">
+                                                {$data_v['name']}
+                                            </a>
+                                            <a class="btn btn-default pull-right product-xs-remove" href="{$rm_v['link']}"><i class="icon-trash"></i></a>
+                                            {block name='displayCartRoomTypeNameAfter'}
+                                                {hook h='displayCartRoomTypeNameAfter' id_product=$data_v['id_product']}
+                                            {/block}
+                                        </p>
+                                    {/block}
+                                    {block name='shopping_cart_room_type_hotel_location'}
+                                        {if isset($data_v['hotel_info']['location'])}
+                                            <p class="hotel-location">
+                                                <i class="icon-map-marker"></i> &nbsp;{$data_v['hotel_info']['location']}
+                                            </p>
+                                        {/if}
+                                    {/block}
+                                    {block name='displayCartRoomTypeInfo'}
+                                        {hook h='displayCartRoomTypeInfo' id_product=$data_v['id_product']}
+                                    {/block}
+                                </div>
+                            {/block}
+                        </div>
+                        {block name='shopping_cart_room_type_features'}
+                            {if isset($data_v['hotel_info']['room_features'])}
+                                <div class="room-type-features">
+                                {foreach $data_v['hotel_info']['room_features'] as $feature}
+                                    <span class="room-type-feature">
+                                        <img src="{$THEME_DIR}img/icon/form-ok-circle.svg" /> {$feature['name']}
+                                    </span>
+                                {/foreach}
+                                </div>
+                            {/if}
+                        {/block}
+                        {block name='shopping_cart_room_type_booking_information'}
+                            {assign var="is_full_date" value=($show_full_date && ($rm_v['data_form']|date_format:'%D' == $rm_v['data_to']|date_format:'%D'))}
+                            <div class="room_duration_block">
+                                <div class="col-sm-3 col-xs-6">
+                                    <p class="room_duration_block_head">{l s='CHECK IN'}</p>
+                                    <p class="room_duration_block_value">{$rm_v['data_form']|date_format:"%d %b, %a"}{if $is_full_date} {$rm_v['data_form']|date_format:"%H:%M"}{/if}</p>
+                                </div>
+                                <div class="col-sm-3 col-xs-6">
+                                    <p class="room_duration_block_head">{l s='CHECK OUT'}</p>
+                                    <p class="room_duration_block_value">{$rm_v['data_to']|date_format:"%d %b, %a"}{if $is_full_date} {$rm_v['data_to']|date_format:"%H:%M"}{/if}</p>
+                                </div>
+                                <div class="col-sm-6 col-xs-6">
+                                    <p class="room_duration_block_head">{l s='OCCUPANCY'}</p>
+                                    <p class="room_duration_block_value">
+                                        {if {$rm_v['adults']} <= 9}0{$rm_v['adults']}{else}{$rm_v['adults']}{/if} {if $rm_v['adults'] > 1}{l s='Adults'}{else}{l s='Adult'}{/if}{if $rm_v['children']}, {if $rm_v['children'] <= 9}0{$rm_v['children']}{else}{$rm_v['children']}{/if} {if $rm_v['children'] > 1}{l s='Children'}{else}{l s='Child'}{/if}{/if}, {if {$rm_v['num_rm']} <= 9}0{/if}{$rm_v['num_rm']}{if $rm_v['num_rm'] > 1} {l s='Rooms'}{else} {l s='Room'}{/if}
+                                    </p>
+                                </div>
+                            </div>
+                        {/block}
+                        {block name='shopping_cart_room_type_price_detail'}
+                            <div class="row room_price_detail_block">
+                                {block name='shopping_cart_room_type_and_service_price'}
+                                    <div class="col-sm-7 margin-btm-sm-10">
+                                        {if $rm_v['amount'] && isset($rm_v['total_price_without_discount']) && $rm_v['total_price_without_discount'] > $rm_v['amount']}
+                                            <span class="room_type_old_price">
+                                                {displayPrice price=$rm_v['total_price_without_discount']|floatval}
+                                            </span>
+                                        {/if}
+                                        <div class="row">
+                                            <div class="{if (isset($data_v['extra_demands']) && $data_v['extra_demands']) || (isset($data_v['service_products']) && $data_v['service_products'])}col-xs-6 plus-sign{else}col-xs-12{/if}">
+                                                <div class="price_block">
+                                                    <p class="total_price">
+                                                        <span>
+                                                            {displayPrice price=($rm_v['amount'])}
+                                                        </span>
+                                                        {if (($rm_v['amount'] - $rm_v['amount_without_auto_add']) > 0) && (in_array($data_v['id_product'], $discounted_products) || $PS_ROOM_PRICE_AUTO_ADD_BREAKDOWN)}
+                                                            <span class="room-price-detail">
+                                                                <img src="{$img_dir}icon/icon-info.svg" />
+                                                            </span>
+                                                            <div class="room-price-detail-container" style="display: none;">
+                                                                <div class="room-price-detail-tooltip-cont">
+                                                                    <div><label>{l s='Room price'}</label> : {displayPrice price=($rm_v['amount_without_auto_add'])}</div>
+                                                                    <div><label>{l s='Additional charges'}</label> : {displayPrice price=($rm_v['amount'] - $rm_v['amount_without_auto_add'])}</div>
+                                                                </div>
+                                                            </div>
+                                                        {/if}
+                                                    </p>
+                                                    <p class="total_price_detial">
+                                                        {l s='Total rooms price'} {if $display_tax_label}{if $priceDisplay} {l s='(Excl.'} {else}{l s='(Incl.)'}{/if} {l s='all taxes.)'}{/if}
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            {if (isset($data_v['extra_demands']) && $data_v['extra_demands']) || (isset($data_v['service_products']) && $data_v['service_products'])}
+                                                <div class="col-xs-6">
+                                                    <div class="demand_price_block">
+                                                        <p class="demand_total_price">
+                                                            <span>
+                                                                {displayPrice price=$rm_v['demand_price']}
+                                                            </span>
+                                                        </p>
+                                                        <p class="total_price_detial">
+                                                            <a data-date_from="{$rm_v['data_form']|escape:'html':'UTF-8'}" data-date_to="{$rm_v['data_to']|escape:'html':'UTF-8'}" data-id_product="{$data_v['id_product']|escape:'html':'UTF-8'}" data-action="{$link->getPageLink('order-opc')}" class="open_rooms_extra_services_panel" href="#rooms_type_extra_services_form">
+                                                                {l s='Extra Services'}
+                                                            </a>
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                            {/if}
+                                        </div>
+                                    </div>
+                                {/block}
+                                {block name='shopping_cart_room_type_total_price'}
+                                    <div class="col-sm-5">
+                                        <div class="total_price_block col-xs-12">
+                                            <p class="total_price">
+                                                <span>
+                                                    {displayPrice price=($rm_v['amount']+$rm_v['demand_price'])}
+                                                </span>
+                                            </p>
+                                            <p class="total_price_detial">
+                                                {l s='Total price for'} {$rm_v['num_days']} {l s='Night(s) stay'}{if $display_tax_label}{if $priceDisplay} {l s='(Excl.'} {else}{l s='(Incl.'}{/if} {l s='all taxes.)'}{/if}
+                                            </p>
+                                        </div>
+                                    </div>
+                                {/block}
+                            </div>
+                        {/block}
+                        {block name='displayCartProductContentAfter'}
+                            {hook h='displayCartProductContentAfter' cart_detail=$data_v key=$rm_k}
+                        {/block}
+                    </div>
+                </div>
+                {block name='displayCartProductAfter'}
+                    {hook h='displayCartProductAfter' cart_detail=$data_v key=$rm_k}
+                {/block}
+                <hr>
+            {/foreach}
+        {/foreach}
+    {/if}
+    {block name='displayAfterShoppingCartRoomsSummary'}
+		{hook h="displayAfterShoppingCartRoomsSummary"}
+	{/block}
+    {if (isset($hotel_products) && $hotel_products) || (isset($standalone_products) && $standalone_products)}
+        <p class="cart_section_title">{l s='Product information'}</p>
+    {/if}
+    {if isset($hotel_products) && $hotel_products}
+        {foreach from=$hotel_products key=data_k item=product}
+            <div class="row cart_product_line">
+                <div class="col-sm-2 product-img-block">
+                    <p>
+                        <a href="{$link->getProductLink($product['id_product'])}">
+                            <img src="{$product['cover_img']}" class="img-responsive" />
+                        </a>
+                    </p>
+
+                    <p class="product_remove_block">
+                        <a id="{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_{if $product.id_hotel}{$product.id_hotel}{else}0{/if}" class="cart_quantity_delete" href="{$link->getPageLink('cart', true, NULL, "delete=1&amp;id_product={$product.id_product|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Delete'}">
+                            <i class="icon-trash"></i> &nbsp;{l s='Remove'}
+                        </a>
+                        {* <a href="{$rm_v['link']}"><i class="icon-trash"></i> &nbsp;{l s='Remove'}</a> *}
+                    </p>
+                    {block name='displayCartProductImageAfter'}
+                        {hook h='displayCartProductImageAfter' id_product=$product['id_product']}
+                    {/block}
+                </div>
+                <div class="col-sm-10">
+                    <div class="product-info-container">
+                        <div class="product-xs-img">
+                            <a href="{$link->getProductLink($product['id_product'])}">
+                                <img src="{$product['cover_img']}" class="img-responsive" />
+                            </a>
+                        </div>
+                        <div class="product-xs-info">
+                            <p class="product-name">
+                                <a href="{$link->getProductLink($product['id_product'])}">
+                                    {$product['name']}{if isset($product['option_name']) && $product['option_name']} : {$product['option_name']}{/if}
+                                </a>
+                                <a class="btn btn-default pull-right product-xs-remove" href="{$link->getPageLink('cart', true, NULL, "delete=1&amp;id_product={$product.id_product|intval}&amp;ipa=0&amp;id_address_delivery={$product.id_address_delivery}&amp;token={$token_cart}")|escape:'html':'UTF-8'}"><i class="icon-trash"></i></a>
+                                {block name='displayCartProductNameAfter'}
+                                    {hook h='displayCartProductNameAfter' id_product=$product['id_product']}
+                                {/block}
+                            </p>
+
+                            {if isset($product['hotel_info']['location'])}
+                                <p class="hotel-location">
+                                    <i class="icon-map-marker"></i> &nbsp;{$product['hotel_info']['location']}
+                                </p>
+                                {block name='displayCartProductHotelLocationAfter'}
+                                    {hook h='displayCartProductHotelLocationAfter' id_product=$product['id_product']}
+                                {/block}
+                            {/if}
+                        </div>
+                    </div>
+                    <div class="row product_price_detail_block">
+                        <div class="col-sm-7">
+                            <div class="price_block col-xs-7">
+                                <p class="total_price">
+                                    <span>
+                                        {if $priceDisplay}{displayPrice price=($product['unit_price_tax_excl'])}{else}{displayPrice price=($product['unit_price_tax_incl'])}{/if}
+                                    </span>
+                                </p>
+                                <p class="total_price_detial">
+                                    {l s='Unit price'} {if $display_tax_label}{if $priceDisplay} {l s='(Excl.'} {else}{l s='(Incl.)'}{/if} {l s='all taxes.)'}{/if}
+                                </p>
+                            </div>
+                            {if $product.allow_multiple_quantity}
+                                <div class="col-xs-5">
+                                    <div class="quantity_cont">
+                                        <input type="hidden" value="{$product.quantity}" name="quantity_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_{if $product.id_hotel}{$product.id_hotel}{else}0{/if}_hidden" />
+                                        <input size="2" type="text" autocomplete="off" class="cart_quantity_input grey" value="{$product.quantity}"  name="quantity_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_{if $product.id_hotel}{$product.id_hotel}{else}0{/if}" />
+                                        <div class="cart_quantity_button">
+                                            <a rel="nofollow" class="cart_quantity_up btn btn-default" id="cart_quantity_up_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_{if $product.id_hotel}{$product.id_hotel}{else}0{/if}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery=0&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Add'}"><span><i class="icon-plus"></i></span></a>
+                                            {if $product.minimal_quantity < ($product.quantity)}
+                                                <a rel="nofollow" class="cart_quantity_down btn btn-default" id="cart_quantity_down_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_{if $product.id_hotel}{$product.id_hotel}{else}0{/if}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery=0&amp;op=down&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Subtract'}">
+                                                    <span><i class="icon-minus"></i></span>
+                                                </a>
+                                            {else}
+                                                <a class="cart_quantity_down btn btn-default disabled" href="#" id="cart_quantity_down_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_{if $product.id_hotel}{$product.id_hotel}{else}0{/if}" title="{l s='You must purchase a minimum of %d of this product.' sprintf=1}">
+                                                    <span><i class="icon-minus"></i></span>
+                                                </a>
+                                            {/if}
+                                        </div>
+                                    </div>
+                                </div>
+                            {/if}
+                        </div>
+                        <div class="col-sm-5">
+                            <div class="total_price_block col-xs-12">
+                                <p class="total_price">
+                                    <span>
+                                        {if $priceDisplay}{displayPrice price=($product['total_price_tax_excl'])}{else}{displayPrice price=($product['total_price_tax_incl'])}{/if}
+                                    </span>
+                                </p>
+                                <p class="total_price_detial">
+                                    {l s='Total price'} {if $display_tax_label}{if $priceDisplay} {l s='(Excl.'} {else}{l s='(Incl.)'}{/if} {l s='all taxes.)'}{/if}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <hr>
+        {/foreach}
+    {/if}
+    {if isset($standalone_products) && $standalone_products}
+        {foreach from=$standalone_products key=data_k item=product}
+            <div class="row cart_product_line">
+                <div class="col-sm-2 product-img-block">
+                    <p>
+                        <a href="{$link->getProductLink($product['id_product'])}">
+                            <img src="{$product['cover_img']}" class="img-responsive" />
+                        </a>
+                    </p>
+
+                    <p class="product_remove_block">
+                        <a id="{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_0" class="cart_quantity_delete" href="{$link->getPageLink('cart', true, NULL, "delete=1&amp;id_product={$product.id_product|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Delete'}">
+                            <i class="icon-trash"></i> &nbsp;{l s='Remove'}
+                        </a>
+                        {* <a href="{$rm_v['link']}"><i class="icon-trash"></i> &nbsp;{l s='Remove'}</a> *}
+                    </p>
+                    {block name='displayCartProductImageAfter'}
+                        {hook h='displayCartProductImageAfter' id_product=$product['id_product']}
+                    {/block}
+
+                </div>
+                <div class="col-sm-10">
+                    <div class="product-info-container">
+                        <div class="product-xs-img">
+                            <a href="{$link->getProductLink($product['id_product'])}">
+                                <img src="{$product['cover_img']}" class="img-responsive" />
+                            </a>
+                        </div>
+                        <div class="product-xs-info">
+                            <p class="product-name">
+                                <a href="{$link->getProductLink($product['id_product'])}">
+                                    {$product['name']}{if isset($product['option_name']) && $product['option_name']} : {$product['option_name']}{/if}
+                                </a>
+                                <a class="btn btn-default pull-right product-xs-remove" href="{$link->getPageLink('cart', true, NULL, "delete=1&amp;id_product={$product.id_product|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}"><i class="icon-trash"></i></a>
+                                {block name='displayCartProductNameAfter'}
+                                    {hook h='displayCartProductNameAfter' id_product=$product['id_product']}
+                                {/block}
+                            </p>
+                        </div>
+                    </div>
+                    <div class="row product_price_detail_block">
+                        <div class="col-sm-7">
+                            <div class="price_block col-xs-7">
+                                <p class="total_price">
+                                    <span>
+                                        {if $priceDisplay}{displayPrice price=($product['unit_price_tax_excl'])}{else}{displayPrice price=($product['unit_price_tax_incl'])}{/if}
+                                    </span>
+                                </p>
+                                <p class="total_price_detial">
+                                    {l s='Unit price'} {if $display_tax_label}{if $priceDisplay} {l s='(Excl.'} {else}{l s='(Incl.)'}{/if} {l s='all taxes.)'}{/if}
+                                </p>
+                            </div>
+                            {if $product.allow_multiple_quantity}
+                                <div class="col-xs-5">
+                                    <div class="quantity_cont">
+                                        <input type="hidden" value="{$product.quantity}" name="quantity_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_0_hidden" />
+                                        <input size="2" type="text" autocomplete="off" class="cart_quantity_input grey" value="{$product.quantity}"  name="quantity_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_0" />
+                                        <div class="cart_quantity_button">
+                                            <a rel="nofollow" class="cart_quantity_up btn btn-default" id="cart_quantity_up_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_0" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Add'}"><span><i class="icon-plus"></i></span></a>
+                                            {if $product.minimal_quantity < ($product.quantity)}
+                                                <a rel="nofollow" class="cart_quantity_down btn btn-default" id="cart_quantity_down_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_0" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;op=down&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Subtract'}">
+                                                    <span><i class="icon-minus"></i></span>
+                                                </a>
+                                            {else}
+                                                <a class="cart_quantity_down btn btn-default disabled" href="#" id="cart_quantity_down_{$product.id_product}_{if $product.id_product_option}{$product.id_product_option}{else}0{/if}_0" title="{l s='You must purchase a minimum of %d of this product.' sprintf=$product.minimal_quantity}">
+                                                    <span><i class="icon-minus"></i></span>
+                                                </a>
+                                            {/if}
+
+                                        </div>
+                                    </div>
+                                </div>
+                            {/if}
+                        </div>
+                        <div class="col-sm-5">
+                            <div class="total_price_block col-xs-12">
+                                <p class="total_price">
+                                    <span>
+                                        {if $priceDisplay}{displayPrice price=($product['total_price_tax_excl'])}{else}{displayPrice price=($product['total_price_tax_incl'])}{/if}
+                                    </span>
+                                </p>
+                                <p class="total_price_detial">
+                                    {l s='Total price'} {if $display_tax_label}{if $priceDisplay} {l s='(Excl.'} {else}{l s='(Incl.)'}{/if} {l s='all taxes.)'}{/if}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {block name='displayCartProductContainerBottom'}
+                    {hook h='displayCartProductContainerBottom' id_product=$product['id_product']}
+                {/block}
+            </div>
+            <hr>
+        {/foreach}
+    {/if}
+
+    {* proceed only if no order restrict errors are there *}
+    {if !$orderRestrictErr}
+        {block name='shopping_cart_proceed_action'}
+            <div class="row">
+                <div class="col-sm-12 proceed_btn_block">
+                    <a class="btn btn-default button button-medium pull-right" href="{$link->getPageLink('order-opc', null, null, ['proceed_to_customer_dtl' => 1])}" title="Proceed to checkout" rel="nofollow">
+                        <span>
+                            {l s='Proceed'}
+                        </span>
+                    </a>
+                </div>
+            </div>
+        {/block}
+    {/if}
+</div>

--- a/themes/hotel-reservation-theme/shopping-cart-product-line.tpl
+++ b/themes/hotel-reservation-theme/shopping-cart-product-line.tpl
@@ -1,1 +1,139 @@
-{include file='_partials/checkout-inquiry-message.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+<tr id="product_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}{if !empty($product.gift)}_gift{/if}" class="cart_item{if isset($productLast) && $productLast && (!isset($ignoreProductLast) || !$ignoreProductLast)} last_item{/if}{if isset($productFirst) && $productFirst} first_item{/if}{if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0} alternate_item{/if} address_{$product.id_address_delivery|intval} {if $odd}odd{else}even{/if}">
+	<td class="cart_product">
+		<a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute, false, false, true)|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'small_default')|escape:'html':'UTF-8'}" alt="{$product.name|escape:'html':'UTF-8'}" {if isset($smallSize)}width="{$smallSize.width}" height="{$smallSize.height}" {/if} /></a>
+	</td>
+	<td class="cart_description">
+		{capture name=sep} : {/capture}
+		{capture}{l s=' : '}{/capture}
+		<p class="product-name"><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute, false, false, true)|escape:'html':'UTF-8'}">{$product.name|escape:'html':'UTF-8'}</a></p>
+			{if $product.reference}<small class="cart_ref">{l s='SKU'}{$smarty.capture.default}{$product.reference|escape:'html':'UTF-8'}</small>{/if}
+		{if isset($product.attributes) && $product.attributes}<small><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute, false, false, true)|escape:'html':'UTF-8'}">{$product.attributes|@replace: $smarty.capture.sep:$smarty.capture.default|escape:'html':'UTF-8'}</a></small>{/if}
+	</td>
+	{if $PS_STOCK_MANAGEMENT}
+		<td class="cart_avail"><span class="label{if $product.quantity_available <= 0 && isset($product.allow_oosp) && !$product.allow_oosp} label-danger{elseif $product.quantity_available <= 0} label-warning{else} label-success{/if}">{if $product.quantity_available <= 0}{if isset($product.allow_oosp) && $product.allow_oosp}{if isset($product.available_later) && $product.available_later}{$product.available_later}{else}{l s='In Stock'}{/if}{else}{l s='Out of stock'}{/if}{else}{if isset($product.available_now) && $product.available_now}{$product.available_now}{else}{l s='In Stock'}{/if}{/if}</span>{if !$product.is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}</td>
+	{/if}
+	<td class="cart_unit" data-title="{l s='Unit price'}">
+		<ul class="price text-right" id="product_price_{$product.id_product}_{$product.id_product_attribute}{if $quantityDisplayed > 0}_nocustom{/if}_{$product.id_address_delivery|intval}{if !empty($product.gift)}_gift{/if}">
+			{if !empty($product.gift)}
+				<li class="gift-icon">{l s='Gift!'}</li>
+			{else}
+            	{if !$priceDisplay}
+					<li class="price{if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies} special-price{/if}">{convertPrice price=$product.price_wt}</li>
+				{else}
+               	 	<li class="price{if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies} special-price{/if}">{convertPrice price=$product.price}</li>
+				{/if}
+				{if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies}
+                	<li class="price-percent-reduction small">
+            			{if !$priceDisplay}
+            				{if isset($product.reduction_type) && $product.reduction_type == 'amount'}
+                    			{assign var='priceReduction' value=($product.price_wt - $product.price_without_specific_price)}
+                    			{assign var='symbol' value=$currency->sign}
+                    		{else}
+                    			{assign var='priceReduction' value=(($product.price_without_specific_price - $product.price_wt)/$product.price_without_specific_price) * 100 * -1}
+                    			{assign var='symbol' value='%'}
+                    		{/if}
+						{else}
+							{if isset($product.reduction_type) && $product.reduction_type == 'amount'}
+								{assign var='priceReduction' value=($product.price - $product.price_without_specific_price)}
+								{assign var='symbol' value=$currency->sign}
+							{else}
+								{assign var='priceReduction' value=(($product.price_without_specific_price - $product.price)/$product.price_without_specific_price) * -100}
+								{assign var='symbol' value='%'}
+							{/if}
+						{/if}
+						{if $symbol == '%'}
+							&nbsp;{$priceReduction|string_format:"%.2f"|regex_replace:"/[^\d]0+$/":""}{$symbol}&nbsp;
+						{else}
+							&nbsp;{convertPrice price=$priceReduction}&nbsp;
+						{/if}
+					</li>
+					<li class="old-price">{convertPrice price=$product.price_without_specific_price}</li>
+				{/if}
+			{/if}
+		</ul>
+	</td>
+
+	<td class="cart_quantity text-center" data-title="{l s='Quantity'}">
+		{if (isset($cannotModify) && $cannotModify == 1)}
+			<span>
+				{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}
+					{$product.customizationQuantityTotal}
+				{else}
+					{$product.cart_quantity-$quantityDisplayed}
+				{/if}
+			</span>
+		{else}
+			{if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0}
+				<span id="cart_quantity_custom_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}" >{$product.customizationQuantityTotal}</span>
+			{/if}
+			{if !isset($customizedDatas.$productId.$productAttributeId) OR $quantityDisplayed > 0}
+
+				<input type="hidden" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}" name="quantity_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}_hidden" />
+				<input size="2" type="text" autocomplete="off" class="cart_quantity_input form-control grey" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}"  name="quantity_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" />
+				<div class="cart_quantity_button clearfix">
+				{if $product.minimal_quantity < ($product.cart_quantity-$quantityDisplayed) OR $product.minimal_quantity <= 1}
+					<a rel="nofollow" class="cart_quantity_down btn btn-default button-minus" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;op=down&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Subtract'}">
+				<span><i class="icon-minus"></i></span>
+				</a>
+				{else}
+					<a class="cart_quantity_down btn btn-default button-minus disabled" href="#" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" title="{l s='You must purchase a minimum of %d of this product.' sprintf=$product.minimal_quantity}">
+					<span><i class="icon-minus"></i></span>
+				</a>
+				{/if}
+					<a rel="nofollow" class="cart_quantity_up btn btn-default button-plus" id="cart_quantity_up_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Add'}"><span><i class="icon-plus"></i></span></a>
+				</div>
+			{/if}
+		{/if}
+	</td>
+
+	{if !isset($noDeleteButton) || !$noDeleteButton}
+		<td class="cart_delete text-center" data-title="{l s='Delete'}">
+		{if (!isset($customizedDatas.$productId.$productAttributeId) OR $quantityDisplayed > 0) && empty($product.gift)}
+			<div>
+				<a rel="nofollow" title="{l s='Delete'}" class="cart_quantity_delete" id="{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "delete=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}"><i class="icon-trash"></i></a>
+			</div>
+		{else}
+
+		{/if}
+		</td>
+	{/if}
+	<td class="cart_total" data-title="{l s='Total'}">
+		<span class="price" id="total_product_price_{$product.id_product}_{$product.id_product_attribute}{if $quantityDisplayed > 0}_nocustom{/if}_{$product.id_address_delivery|intval}{if !empty($product.gift)}_gift{/if}">
+			{if !empty($product.gift)}
+				<span class="gift-icon">{l s='Gift!'}</span>
+			{else}
+				{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}
+					{if !$priceDisplay}{displayPrice price=$product.total_customization_wt}{else}{displayPrice price=$product.total_customization}{/if}
+				{else}
+					{if !$priceDisplay}{displayPrice price=$product.total_wt}{else}{displayPrice price=$product.total}{/if}
+				{/if}
+			{/if}
+		</span>
+		{hook h='displayCartExtraProductActions' product=$product}
+	</td>
+
+</tr>

--- a/themes/hotel-reservation-theme/shopping-cart.tpl
+++ b/themes/hotel-reservation-theme/shopping-cart.tpl
@@ -1,1 +1,94 @@
-{extends file='checkout-inquiry.tpl'}
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{capture name=path}{l s='Your shopping cart'}{/capture}
+
+{* <h1 id="cart_title" class="page-heading">{l s='Shopping-cart summary'}
+	{if !isset($empty) && !$PS_CATALOG_MODE}
+		<span class="heading-counter">{l s='Your shopping cart contains:'}
+			<span id="summary_products_quantity">{$productNumber} {if $productNumber == 1}{l s='product'}{else}{l s='products'}{/if}</span>
+		</span>
+	{/if}
+</h1> *}
+
+{if isset($account_created)}
+	<p class="alert alert-success">
+		{l s='Your account has been created.'}
+	</p>
+{/if}
+
+{assign var='current_step' value='summary'}
+{block name='errors'}
+	{include file="$tpl_dir./order-steps.tpl"}
+{/block}
+
+{if isset($empty)}
+	<p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
+{elseif $PS_CATALOG_MODE}
+	<p class="alert alert-warning">{l s='This store has not accepted your new order.'}</p>
+{else}
+	<p id="emptyCartWarning" class="alert alert-warning unvisible">{l s='Your shopping cart is empty.'}</p>
+	{* eu-legal *}
+	{block name='displayBeforeShoppingCartBlock'}
+		{hook h="displayBeforeShoppingCartBlock"}
+	{/block}
+
+	{block name='shopping_cart_detail'}
+		{include file="$tpl_dir./shopping-cart-detail.tpl"}
+	{/block}
+
+	{if $show_option_allow_separate_package}
+	<p>
+		<label for="allow_seperated_package" class="checkbox inline">
+			<input type="checkbox" name="allow_seperated_package" id="allow_seperated_package" {if $cart->allow_seperated_package}checked="checked"{/if} autocomplete="off"/>
+			{l s='Send available products first'}
+		</label>
+	</p>
+	{/if}
+
+	{block name='displayShoppingCartFooter'}
+		<div id="HOOK_SHOPPING_CART">{$HOOK_SHOPPING_CART}</div>
+	{/block}
+
+	<div class="clear"></div>
+	<div class="cart_navigation_extra">
+		{block name='displayShoppingCart'}
+			<div id="HOOK_SHOPPING_CART_EXTRA">{if isset($HOOK_SHOPPING_CART_EXTRA)}{$HOOK_SHOPPING_CART_EXTRA}{/if}</div>
+		{/block}
+	</div>
+	{block name='shopping_cart_js_vars'}
+		{strip}
+			{addJsDef deliveryAddress=$cart->id_address_delivery|intval}
+			{addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
+			{addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
+		{/strip}
+	{/block}
+{/if}
+
+{* Fancybox for extra demands*}
+{block name='shopping_cart_extra_services'}
+	<div style="display:none;" id="rooms_extra_services">
+	</div>
+{/block}

--- a/tools/dev-router.php
+++ b/tools/dev-router.php
@@ -1,10 +1,11 @@
 <?php
-$projectRoot = realpath(__DIR__ . '/..');
+$projectRoot = rtrim(realpath(__DIR__ . '/..'), DIRECTORY_SEPARATOR);
+$rootPrefix = $projectRoot . DIRECTORY_SEPARATOR;
 $requestUri = $_SERVER['REQUEST_URI'] ?? '/';
 $parsedPath = parse_url($requestUri, PHP_URL_PATH) ?: '/';
 $filePath = realpath($projectRoot . $parsedPath);
 
-if ($filePath !== false && str_starts_with($filePath, $projectRoot) && is_file($filePath)) {
+if ($filePath !== false && strncmp($filePath, $rootPrefix, strlen($rootPrefix)) === 0 && is_file($filePath)) {
     return false; // Serve the requested resource as-is.
 }
 


### PR DESCRIPTION
## Summary
- restore the legacy order and order-opc controllers while adding inquiry-mode guards that redirect browsers and return JSON errors to AJAX clients
- reinstate the full checkout template set so disabling inquiry mode immediately revives the classic cart flow
- document the restored fallback behaviour and friendly inquiry-mode errors across the concept, checklist, roadmap and README

## Testing
- php -l controllers/front/ParentOrderController.php
- php -l controllers/front/OrderController.php
- php -l controllers/front/OrderOpcController.php

------
https://chatgpt.com/codex/tasks/task_e_68d57ef4d9948321afedc9e0462a60d6