### PR TITLE
Address maintenance backlog for PHP constraint and inquiry preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .project
 .settings
 .idea
+.venv/
 .svn
 .DS_Store
 .sass-cache

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ The helper script creates (or reuses) a local Python virtual environment at `.ve
 
 After installation you can log into the admin back office at `/admin` (rename the directory for security). The module catalogue will no longer attempt to connect to external stores; only locally available modules are listed.
 
+## Known issues
+
+We are tracking the current bug backlog in [`docs/issues.md`](docs/issues.md). Highlights from the latest maintenance round:
+
+- Composer now targets PHP 8.1–8.4, matching the runtime guidance above.
+- The inquiry quote preview AJAX endpoint relays payloads that align with `KLQuotePricingEngine::generateQuote()` and preserve submitted occupancy details.
+- `./start_dev.sh` bootstraps tooling without leaving a `.venv/` directory tracked by Git.
+
 ### Resource taxonomy seeding
 
 Existing databases upgraded to the Kunstort fork can populate taxonomy metadata by running:

--- a/checklist.md
+++ b/checklist.md
@@ -39,6 +39,11 @@
 ## In Progress
 - [ ] Add manual operations task authoring, assignment workflows and mobile-friendly checklists building on the new automation hooks.
 
+## Issues
+- [x] Align Composer's PHP requirement with the documented PHP 8 support window so installs work on current runtimes.
+- [x] Fix the inquiry quote preview endpoint payload so it talks to `KLQuotePricingEngine::generateQuote()` and respects submitted occupancy.
+- [x] Ignore the `.venv` directory created by `start_dev.sh` to keep repositories clean after running the dev helper.
+
 ## Planned
 - [ ] Rebuild front-office templates around availability storytelling (see [`devtasks/front-office-storytelling.task.md`](devtasks/front-office-storytelling.task.md)).
 - [ ] Layer internal notification channels on top of inquiry/timeline events once the operations hooks are in place.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": ">=5.4 <8.0",
+        "php": ">=8.1 <8.5",
         "ext-simplexml": "*",
         "ext-curl": "*",
         "ext-gd": "*",

--- a/concept.md
+++ b/concept.md
@@ -51,6 +51,8 @@ Detailed task briefs now live in [`devtasks/`](devtasks/) to coordinate executio
 
 These additions extend the original near-term plan without changing the underlying principle: resource clarity first, then progressive automation that remains transparent to staff.
 
+Maintenance notes and any new regressions live in [`docs/issues.md`](docs/issues.md); the latest sweep aligned Composer's PHP constraint with our PHP 8 guidance, repaired the inquiry quote preview payload and ignored the `.venv/` helper environment.
+
 ## Longer-Term Ideas
 - Replace leftover commerce terminology in the database schema and UI strings.
 - Introduce CSV/ICS export for residency and seminar planning.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,0 +1,9 @@
+# Known Issues
+
+This document tracks technical gaps and regressions identified during code review. All previously logged items were resolved in the current maintenance pass:
+
+- Composer now advertises the supported PHP 8.1–8.4 window so dependency installs succeed on our documented runtimes.
+- The inquiry quote preview endpoint now sends pricing payloads that match `KLQuotePricingEngine::generateQuote()`, including the submitted occupancy counts.
+- `.venv/` is ignored at the repository root so running `start_dev.sh` no longer leaves a dirty working tree.
+
+We will append fresh issues here as they arise.

--- a/modules/hotelreservationsystem/controllers/front/InquiryLookupModuleFrontController.php
+++ b/modules/hotelreservationsystem/controllers/front/InquiryLookupModuleFrontController.php
@@ -153,22 +153,23 @@ class HotelReservationSystemInquiryLookupModuleFrontController extends ModuleFro
             throw new PrestaShopException('Missing parameters for quote preview.');
         }
 
+        $idLang = (int) $this->context->language->id;
+
         $options = array(
-            'id_resource_profile' => $idResource,
-            'id_rate_plan' => $idRatePlan,
-            'id_package' => $idPackage ?: null,
-            'date_in' => $checkIn,
-            'date_out' => $checkOut,
+            'id_kl_resource_profile' => $idResource,
+            'id_kl_rate_plan' => $idRatePlan,
+            'id_kl_package' => $idPackage ?: 0,
+            'check_in' => $checkIn,
+            'check_out' => $checkOut,
+            'id_lang' => $idLang,
         );
 
         $partyAdults = (int) Tools::getValue('party_adults');
         $partyChildren = (int) Tools::getValue('party_children');
         if ($partyAdults > 0 || $partyChildren > 0) {
             $options['occupancy'] = array(
-                array(
-                    'adults' => max(0, $partyAdults),
-                    'children' => max(0, $partyChildren),
-                ),
+                'adults' => max(0, $partyAdults),
+                'children' => max(0, $partyChildren),
             );
         }
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -32,4 +32,9 @@ This roadmap tracks how the Kunstort Lehnin fork evolves from a de-bloated QloAp
 - ⏳ **Programme publishing bridge** – sync curated events and residencies to the public Kunstort Lehnin website or other storytelling channels.
 - ⏳ **External API strategy** – design modern, scoped APIs (authenticated modules, webhook patterns) to replace the retired PrestaShop webservice when needed.
 
+## Maintenance backlog (✅ Recently resolved)
+- ✅ Composer now advertises the PHP 8.1–8.4 window documented in our requirements.
+- ✅ The inquiry quote preview AJAX payload matches `KLQuotePricingEngine::generateQuote()` and keeps the submitted occupancy counts intact.
+- ✅ `.venv/` is ignored so `start_dev.sh` no longer leaves the repository in a dirty state.
+
 We iterate through the roadmap top-to-bottom: hardening the base, completing inquiry workflows, enriching resource data, automating internal operations, and finally exposing analytics and integrations once the core experience is stable.


### PR DESCRIPTION
## Summary
- raise the Composer PHP requirement to the documented PHP 8.1–8.4 window and ensure the manifest has a newline terminator
- align the inquiry quote preview controller payload with the KLQuotePricingEngine contract and pass through occupancy counts
- ignore the start_dev.sh virtualenv directory and update project docs (README, concept, checklist, roadmap, docs/issues.md) to reflect the resolved maintenance items

## Testing
- php -l modules/hotelreservationsystem/controllers/front/InquiryLookupModuleFrontController.php

------
https://chatgpt.com/codex/tasks/task_e_68d63f58f7cc8321a12df6b6bcde2e34