### PR TITLE
Add slot-level inquiry CTAs to storytelling availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Key characteristics of the fork:
 - 🧾 **Taxonomy editor enhancements** – amenity assignments, inline capacity validation, change history snapshots and residency showcase previews live directly inside the Resource Profiles form so staff can review impact before publishing.
 - 🏷️ **Amenity catalogue manager** – a new Catalog → Amenities screen lets staff create reusable amenity codes, toggle availability and capture icon/translation metadata in preparation for resource-level linking.
 - 🧮 **Room-type seeding helper** – install/upgrade flows and `modules/hotelreservationsystem/tools/seed_resource_profiles.php` backfill taxonomy profiles and capacities for existing room types so legacy data is represented immediately.
-- 🧶 **Storytelling scaffolding** – feature-flagged residencies (`index.php?controller=residencies`), ateliers (`index.php?controller=ateliers`), gastronomy (`index.php?controller=gastronomy`) and programme (`index.php?controller=programme`) landings now pull taxonomy-driven sections, featured packages, grouped availability snapshots, amenity callouts and CMS-managed hero/highlight/practical/FAQ/testimonial slots when `_KUNSTORT_STORYTELLING_LAUNCH_` is enabled.
+- 🧶 **Storytelling scaffolding** – feature-flagged residencies (`index.php?controller=residencies`), ateliers (`index.php?controller=ateliers`), gastronomy (`index.php?controller=gastronomy`) and programme (`index.php?controller=programme`) landings now pull taxonomy-driven sections, featured packages, grouped availability snapshots, amenity callouts, slot-level inquiry CTAs and CMS-managed hero/highlight/practical/FAQ/testimonial slots when `_KUNSTORT_STORYTELLING_LAUNCH_` is enabled.
 - 🖼️ **Hero media pipeline** – taxonomy stories expose hero media references and alt text; the theme ships `npm run build:hero-media` to emit responsive WebP/JPEG variants while storytelling templates render lazy-loaded `<picture>` elements with accessible captions.
 - 💼 **Rate plan & quote engine** – the module now ships database tables and `ObjectModel` classes for rate plans, seasonal modifiers, bundled packages and inquiry-linked quotes, and the `KLQuotePricingEngine` turns those definitions into inquiry-ready pricing breakdowns.
 - 🗓️ **Rate plan console** – manage plan metadata, eligibility scopes and seasonal adjustments directly from the back office.
@@ -53,6 +53,8 @@ window.klStorytellingDeferQueue.push({ src: 'https://example.test/analytics.js',
 ```
 
 or output `<template data-kl-storytelling-defer data-src="/modules/feature.js" data-kl-async>` from a module hooked into `displayStorytellingScripts`. The helper processes queued entries after the `load` event, appending scripts with `defer`/`async` semantics so analytics widgets, galleries and other enhancements stay out of the critical rendering path.
+
+Availability snapshots surface CTA buttons beside each slot; the presenter now emits slot-specific inquiry URLs so clicking a CTA opens the inquiry form with arrival/departure fields, resource kind and the highlighted resource code already filled in.
 
 - **Residencies CMS keys:** `KL_STORY_RESIDENCIES_HERO`, `KL_STORY_RESIDENCIES_AVAILABILITY`, `KL_STORY_RESIDENCIES_PRACTICAL`, `KL_STORY_RESIDENCIES_FAQ`, `KL_STORY_RESIDENCIES_TESTIMONIALS`.
 - **Ateliers CMS keys:** `KL_STORY_ATELIERS_HERO`, `KL_STORY_ATELIERS_AVAILABILITY`, `KL_STORY_ATELIERS_PRACTICAL`, `KL_STORY_ATELIERS_FAQ`, `KL_STORY_ATELIERS_TESTIMONIALS`.

--- a/checklist.md
+++ b/checklist.md
@@ -51,6 +51,7 @@
   - [x] Introduce a shared storytelling style layer (`storytelling.scss` → `storytelling.css`) with responsive layouts, WCAG-compliant colour tokens and inline critical hero rules.
   - [x] Add the `klStorytellingDefer` helper plus template hooks so non-critical scripts lazy-load after the main storytelling paint.
   - [x] Pipe taxonomy hero media into responsive `<picture>` components with lazy loading, captions and WebP/JPEG variants generated via `npm run build:hero-media`.
+  - [x] Wire slot-specific inquiry CTAs so availability windows launch the inquiry form with matching resource codes and dates prefilled.
   - [ ] Port shared components to ateliers/studios, gastronomy and programme templates.
   - [ ] Wire CMS content keys, testimonial feed and FAQ data sources.
   - [ ] Add Lighthouse/Panther regression tests for performance and accessibility budgets.

--- a/concept.md
+++ b/concept.md
@@ -37,6 +37,7 @@ Create a lean, fully self-hosted hospitality operations tool tailored to Kunstor
 - Storytelling landings now share a dedicated SCSS/CSS bundle with inline critical hero rules and a lightweight deferral helper so responsive layouts load quickly while non-essential scripts queue behind the new `klStorytellingDefer` API.
 - Storytelling templates now hydrate hero media from taxonomy stories, outputting responsive `<picture>` blocks with lazy-loaded WebP/JPEG variants generated via `npm run build:hero-media`; captions and alt text stay in sync with `KLResourceStory` metadata so accessibility guidance travels with editorial copy.
 - The residencies landing availability snapshot now queries live bookings and maintenance blocks, surfaces the earliest openings per resource kind and caches the summary for 15 minutes so visitors see timely inquiry prompts without hammering the booking tables.
+- Availability slots across residencies, ateliers, gastronomy and programme storytelling landings now display per-slot inquiry CTAs that deep-link into the inquiry form with arrival/departure dates, resource kind and resource codes prefilled.
 - Legacy PrestaShop webservice entry points are stubbed; `/webservice` responds with HTTP 410 and no admin UI exposes API keys.
 - A repo-level `start_dev.sh` script provisions a Python virtualenv for tooling, keeps Composer dependencies current, and boots the PHP built-in server for local testing.
 

--- a/controllers/front/InquiryController.php
+++ b/controllers/front/InquiryController.php
@@ -37,6 +37,7 @@ class InquiryControllerCore extends FrontController
         $this->addJS(_THEME_JS_DIR_.'inquiry-form.js');
 
         $resourceKindOptions = $this->getResourceKindOptions();
+        $this->bootstrapFormValues($resourceKindOptions);
 
         $this->context->smarty->assign(array(
             'form_values' => $this->formValues,
@@ -116,6 +117,68 @@ class InquiryControllerCore extends FrontController
             'consent_data_usage' => Tools::getValue('consent_data_usage') ? true : false,
             'consent_newsletter' => Tools::getValue('consent_newsletter') ? true : false,
         );
+
+        return $values;
+    }
+
+    /**
+     * @param array<string, string> $resourceKindOptions
+     *
+     * @return void
+     */
+    protected function bootstrapFormValues(array $resourceKindOptions)
+    {
+        $defaults = array(
+            'guest_name' => '',
+            'guest_email' => '',
+            'guest_phone' => '',
+            'programme_focus' => '',
+            'arrival_date' => '',
+            'departure_date' => '',
+            'date_flexibility' => false,
+            'party_size_adults' => 1,
+            'party_size_children' => 0,
+            'resource_interests' => array(),
+            'resource_notes' => '',
+            'package_preferences' => array(),
+            'additional_notes' => '',
+            'consent_data_usage' => false,
+            'consent_newsletter' => false,
+        );
+
+        $prefill = $this->getQueryPrefillValues($resourceKindOptions);
+
+        $this->formValues = array_merge($defaults, $prefill, $this->formValues);
+    }
+
+    /**
+     * @param array<string, string> $resourceKindOptions
+     *
+     * @return array<string, mixed>
+     */
+    protected function getQueryPrefillValues(array $resourceKindOptions)
+    {
+        $values = array();
+
+        $arrival = Tools::getValue('arrival_date');
+        if ($arrival && Validate::isDateFormat($arrival)) {
+            $values['arrival_date'] = $arrival;
+        }
+
+        $departure = Tools::getValue('departure_date');
+        if ($departure && Validate::isDateFormat($departure)) {
+            $values['departure_date'] = $departure;
+        }
+
+        $resourceKind = Tools::getValue('resource_kind');
+        if ($resourceKind && is_string($resourceKind) && isset($resourceKindOptions[$resourceKind])) {
+            $values['resource_interests'] = array($resourceKind);
+        }
+
+        $resourceCode = trim((string) Tools::getValue('resource_code'));
+        if ($resourceCode !== '') {
+            $values['resource_notes'] = $resourceCode;
+        }
 
         return $values;
     }

--- a/devtasks/storytelling-availability-cta.task.md
+++ b/devtasks/storytelling-availability-cta.task.md
@@ -1,0 +1,30 @@
+# Task Brief: Storytelling Availability CTA Enhancements
+
+## Objective
+Layer actionable inquiry calls-to-action into the storytelling availability widgets so visitors can jump straight into an inquiry pre-filled with the slot they are viewing.
+
+## Key Deliverables
+- Extend the storytelling presenter so each availability slot includes structured inquiry query parameters for the highlighted resource, arrival and departure dates.
+- Generate slot-specific inquiry URLs on the landing payloads while preserving existing UTM tracking per page.
+- Render compact CTA buttons next to every availability slot (including grouped variants) across residencies, ateliers, gastronomy and programme templates.
+- Prefill the inquiry form with arrival/departure dates, resource kind and the surfaced resource code whenever those query parameters are present.
+
+## Technical Considerations
+- The presenter already caches availability snapshots; attach CTA data without mutating the cached payload stored under the existing cache keys.
+- Use RFC 3986 query encoding when composing CTA URLs so resource codes with special characters survive the redirect.
+- Keep the storytelling styles responsive—buttons should stack beneath the slot summary on small screens and align to the right on wider breakpoints.
+- Ensure the new query parameters do not break validation in `InquiryController`; only accept values that pass the existing date and resource kind checks.
+
+## Dependencies & Coordination
+- Confirm with the design/content team that CTA copy matches current inquiry messaging.
+- Coordinate with operations to make sure prefilled resource notes align with the identifiers they expect during triage.
+
+## Acceptance Criteria
+- CTA buttons appear alongside every availability slot on all storytelling landings when `_KUNSTORT_STORYTELLING_LAUNCH_` is enabled.
+- Clicking a CTA opens the inquiry page with arrival/departure inputs filled, the relevant resource kind pre-selected and the surfaced resource code noted.
+- The inquiry form still validates correctly when loaded without CTA parameters.
+- Documentation (`concept.md`, `checklist.md`, `README.md`, `roadmap.md`) reflects the CTA enhancement.
+
+## QA Notes
+- Smoke-test each storytelling landing to confirm CTA visibility and responsive layout behaviour.
+- Submit a test inquiry from a CTA URL and verify the payload logged on the Kanban board includes the prefilled values.

--- a/devtasks/tasks.md
+++ b/devtasks/tasks.md
@@ -12,5 +12,6 @@ This folder tracks near-term development efforts for the Kunstort Lehnin fork. E
 | [Programme storytelling landing](storytelling-programme.task.md) | ✅ Complete | Ship the programme-focused storytelling page with grouped availability, CMS highlights and inquiry pathways. |
 | [Storytelling style layer](storytelling-style-layer.task.md) | 🚧 In progress | Introduce the dedicated storytelling stylesheet, critical CSS inline block and deferral hooks for non-critical scripts. |
 | [Storytelling hero media](storytelling-hero-media.task.md) | 🚧 In progress | Stand up the hero media pipeline, responsive `<picture>` markup and asset tooling for storytelling templates. |
+| [Storytelling availability CTAs](storytelling-availability-cta.task.md) | 🚧 In progress | Surface inquiry buttons on availability slots and prefill the inquiry form from slot metadata. |
 
 Update this table whenever task briefs change status or new tasks are added.

--- a/modules/hotelreservationsystem/classes/HotelReservationSystemStorytellingPresenter.php
+++ b/modules/hotelreservationsystem/classes/HotelReservationSystemStorytellingPresenter.php
@@ -110,11 +110,16 @@ class HotelReservationSystemStorytellingPresenter
         $idLang = $idLang !== null ? (int) $idLang : ($context && $context->language ? (int) $context->language->id : (int) Configuration::get('PS_LANG_DEFAULT'));
         $idShop = $idShop !== null ? (int) $idShop : ($context && $context->shop ? (int) $context->shop->id : 0);
 
+        $availability = $this->buildAvailabilitySnapshot($idLang, $idShop);
+        $availability = $this->applyInquiryUrls($availability, array(
+            'utm_source' => 'story_residencies',
+        ));
+
         return array(
             'generated_at' => date(DATE_ATOM),
             'sections' => $this->groupProfilesByKind($idLang, $idShop),
             'section_metadata' => $this->getSectionMetadata($idLang, $idShop),
-            'availability' => $this->buildAvailabilitySnapshot($idLang, $idShop),
+            'availability' => $availability,
             'cms' => $this->resolveCmsSlots('residencies', $idLang, $idShop),
             'packages' => $this->getFeaturedPackages($idLang),
             'inquiry_url' => $context && $context->link
@@ -141,11 +146,16 @@ class HotelReservationSystemStorytellingPresenter
 
         $resourceKinds = array(KLResourceProfile::RESOURCE_KIND_ATELIER);
 
+        $availability = $this->buildAvailabilitySnapshot($idLang, $idShop, $resourceKinds);
+        $availability = $this->applyInquiryUrls($availability, array(
+            'utm_source' => 'story_ateliers',
+        ));
+
         return array(
             'generated_at' => date(DATE_ATOM),
             'sections' => $this->groupProfilesByKind($idLang, $idShop, $resourceKinds),
             'section_metadata' => $this->getSectionMetadata($idLang, $idShop, $resourceKinds),
-            'availability' => $this->buildAvailabilitySnapshot($idLang, $idShop, $resourceKinds),
+            'availability' => $availability,
             'cms' => $this->resolveCmsSlots('ateliers', $idLang, $idShop),
             'packages' => $this->filterPackagesByResourceKinds(
                 $this->getFeaturedPackages($idLang),
@@ -175,11 +185,16 @@ class HotelReservationSystemStorytellingPresenter
 
         $resourceKinds = array(KLResourceProfile::RESOURCE_KIND_GASTRONOMY);
 
+        $availability = $this->buildAvailabilitySnapshot($idLang, $idShop, $resourceKinds);
+        $availability = $this->applyInquiryUrls($availability, array(
+            'utm_source' => 'story_gastronomy',
+        ));
+
         return array(
             'generated_at' => date(DATE_ATOM),
             'sections' => $this->groupProfilesByKind($idLang, $idShop, $resourceKinds),
             'section_metadata' => $this->getSectionMetadata($idLang, $idShop, $resourceKinds),
-            'availability' => $this->buildAvailabilitySnapshot($idLang, $idShop, $resourceKinds),
+            'availability' => $availability,
             'cms' => $this->resolveCmsSlots('gastronomy', $idLang, $idShop),
             'packages' => $this->filterPackagesByResourceKinds(
                 $this->getFeaturedPackages($idLang),
@@ -209,11 +224,16 @@ class HotelReservationSystemStorytellingPresenter
 
         $resourceKinds = array(KLResourceProfile::RESOURCE_KIND_SEMINAR);
 
+        $availability = $this->buildAvailabilitySnapshot($idLang, $idShop, $resourceKinds);
+        $availability = $this->applyInquiryUrls($availability, array(
+            'utm_source' => 'story_programme',
+        ));
+
         return array(
             'generated_at' => date(DATE_ATOM),
             'sections' => $this->groupProfilesByKind($idLang, $idShop, $resourceKinds),
             'section_metadata' => $this->getSectionMetadata($idLang, $idShop, $resourceKinds),
-            'availability' => $this->buildAvailabilitySnapshot($idLang, $idShop, $resourceKinds),
+            'availability' => $availability,
             'cms' => $this->resolveCmsSlots('programme', $idLang, $idShop),
             'packages' => $this->filterPackagesByResourceKinds(
                 $this->getFeaturedPackages($idLang),
@@ -1046,12 +1066,29 @@ class HotelReservationSystemStorytellingPresenter
             : $this->getResourceKindLabel($slot['resource_kind']);
         $sectionIntro = isset($sectionMetadata['intro']) ? $sectionMetadata['intro'] : '';
 
+        $arrivalDate = $start->format('Y-m-d');
+        $departureDate = $end->format('Y-m-d');
+        $inquiryParams = array(
+            'arrival_date' => $arrivalDate,
+            'departure_date' => $departureDate,
+        );
+        if (!empty($slot['resource_kind'])) {
+            $inquiryParams['resource_kind'] = $slot['resource_kind'];
+        }
+        if (!empty($profile['resource_code'])) {
+            $inquiryParams['resource_code'] = $profile['resource_code'];
+        }
+
+        $inquiryQuery = http_build_query($inquiryParams, '', '&', PHP_QUERY_RFC3986);
+
         return array(
             'resource_kind' => $slot['resource_kind'],
             'label' => $sectionLabel,
             'window' => implode(' · ', $windowParts),
             'start' => $start->format(DATE_ATOM),
             'end' => $end->format(DATE_ATOM),
+            'start_date' => $arrivalDate,
+            'end_date' => $departureDate,
             'available_rooms' => $slot['available_rooms'],
             'total_rooms' => $slot['total_rooms'],
             'profile_code' => $profile['resource_code'],
@@ -1059,6 +1096,8 @@ class HotelReservationSystemStorytellingPresenter
             'section_key' => $sectionKey,
             'section_anchor' => $sectionAnchor,
             'section_intro' => $sectionIntro,
+            'inquiry_params' => $inquiryParams,
+            'inquiry_query' => $inquiryQuery,
         );
     }
 
@@ -1417,6 +1456,82 @@ class HotelReservationSystemStorytellingPresenter
         $this->storeAvailabilityCache($cacheKey, $payload);
 
         return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $availability
+     * @param array<string, string> $baseParameters
+     *
+     * @return array<string, mixed>
+     */
+    protected function applyInquiryUrls(array $availability, array $baseParameters = array())
+    {
+        if (!$availability) {
+            return $availability;
+        }
+
+        $link = $this->context && $this->context->link ? $this->context->link : null;
+        if (!$link) {
+            return $availability;
+        }
+
+        if (isset($availability['slots']) && is_array($availability['slots'])) {
+            $availability['slots'] = $this->decorateSlotsWithInquiryUrl($availability['slots'], $baseParameters, $link);
+        }
+
+        if (isset($availability['groups']) && is_array($availability['groups'])) {
+            foreach ($availability['groups'] as $groupKey => $group) {
+                if (isset($group['slot']) && is_array($group['slot'])) {
+                    $group['slot'] = $this->decorateSlotWithInquiryUrl($group['slot'], $baseParameters, $link);
+                }
+                if (isset($group['slots']) && is_array($group['slots'])) {
+                    $group['slots'] = $this->decorateSlotsWithInquiryUrl($group['slots'], $baseParameters, $link);
+                }
+                $availability['groups'][$groupKey] = $group;
+            }
+        }
+
+        return $availability;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $slots
+     * @param array<string, string> $baseParameters
+     * @param Link $link
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function decorateSlotsWithInquiryUrl(array $slots, array $baseParameters, Link $link)
+    {
+        foreach ($slots as $index => $slot) {
+            if (!is_array($slot)) {
+                continue;
+            }
+
+            $slots[$index] = $this->decorateSlotWithInquiryUrl($slot, $baseParameters, $link);
+        }
+
+        return $slots;
+    }
+
+    /**
+     * @param array<string, mixed> $slot
+     * @param array<string, string> $baseParameters
+     * @param Link $link
+     *
+     * @return array<string, mixed>
+     */
+    protected function decorateSlotWithInquiryUrl(array $slot, array $baseParameters, Link $link)
+    {
+        if (!isset($slot['inquiry_params']) || !is_array($slot['inquiry_params'])) {
+            return $slot;
+        }
+
+        $parameters = array_merge($baseParameters, $slot['inquiry_params']);
+        $slot['inquiry_url'] = $link->getPageLink('inquiry', true, null, $parameters);
+        $slot['inquiry_query'] = http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
+
+        return $slot;
     }
 
     /**

--- a/roadmap.md
+++ b/roadmap.md
@@ -27,6 +27,7 @@ This roadmap tracks how the Kunstort Lehnin fork evolves from a de-bloated QloAp
   - ✅ Programme storytelling landing layers grouped availability cues, CMS-managed highlights/schedule/inquiry slots and feature-flagged navigation/sitemap links for `/index.php?controller=programme`.
   - ✅ Storytelling style layer ships with a shared SCSS/CSS bundle, inline critical hero rules and a `klStorytellingDefer` helper so optional scripts load after first paint.
   - ✅ Storytelling hero media pipeline generates WebP/JPEG variants via `npm run build:hero-media`, exposes taxonomy alt text in the presenter payload and renders lazy-loaded `<picture>` components with accessible captions across all storytelling templates.
+  - ✅ Storytelling availability slots now surface CTA buttons wired to slot-specific inquiry URLs so arrival/departure dates, resource kind and resource codes prefill the inquiry flow.
 
 ## Phase 3 – Operations Automation (🚧 In progress)
 - ✅ **Housekeeping automation** – the `kloperations` module now generates arrival/checkout housekeeping tasks via cron, syncs booking lifecycle statuses and exposes an Operations → Tasks console. Architectural notes live in [`docs/blueprints/operations-automation.md`](docs/blueprints/operations-automation.md) with implementation details tracked in [`devtasks/operations-automation.task.md`](devtasks/operations-automation.task.md).

--- a/themes/hotel-reservation-theme/css/storytelling.css
+++ b/themes/hotel-reservation-theme/css/storytelling.css
@@ -145,18 +145,31 @@
   display: grid;
   gap: 0.75rem;
   margin: 0;
+  padding: 0;
 }
-.kl-storytelling__availability-slots li {
-  align-items: baseline;
+.kl-storytelling__availability-slot {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem 1.5rem;
+}
+@media (min-width: 40rem) {
+  .kl-storytelling__availability-slot {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+}
+.kl-storytelling__availability-slot .btn {
+  justify-self: start;
+}
+@media (max-width: 39.9375rem) {
+  .kl-storytelling__availability-slot .btn {
+    width: 100%;
+  }
+}
+.kl-storytelling__availability-slot-meta {
   display: grid;
   gap: 0.35rem;
 }
-@media (min-width: 40rem) {
-  .kl-storytelling__availability-slots li {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  }
-}
-.kl-storytelling__availability-slots strong {
+.kl-storytelling__availability-slot-meta strong {
   font-weight: 600;
 }
 .kl-storytelling__sections {

--- a/themes/hotel-reservation-theme/sass/storytelling.scss
+++ b/themes/hotel-reservation-theme/sass/storytelling.scss
@@ -180,16 +180,32 @@ $storytelling-transition: 180ms ease;
   display: grid;
   gap: 0.75rem;
   margin: 0;
+  padding: 0;
+}
 
-  li {
-    align-items: baseline;
-    display: grid;
-    gap: 0.35rem;
+.kl-storytelling__availability-slot {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem 1.5rem;
 
-    @media (min-width: 40rem) {
-      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  @media (min-width: 40rem) {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .btn {
+    justify-self: start;
+  }
+
+  @media (max-width: 39.9375rem) {
+    .btn {
+      width: 100%;
     }
   }
+}
+
+.kl-storytelling__availability-slot-meta {
+  display: grid;
+  gap: 0.35rem;
 
   strong {
     font-weight: 600;

--- a/themes/hotel-reservation-theme/storytelling/ateliers.tpl
+++ b/themes/hotel-reservation-theme/storytelling/ateliers.tpl
@@ -55,9 +55,14 @@
         {if isset($storytelling.availability.slots) && $storytelling.availability.slots}
           <ul class="list-unstyled kl-storytelling__availability-slots">
             {foreach from=$storytelling.availability.slots item=slot}
-              <li>
-                <strong>{$slot.label|escape:'html':'UTF-8'}</strong>
-                <span class="text-muted">{$slot.window|escape:'html':'UTF-8'}</span>
+              <li class="kl-storytelling__availability-slot">
+                <div class="kl-storytelling__availability-slot-meta">
+                  <strong>{$slot.label|escape:'html':'UTF-8'}</strong>
+                  <span class="text-muted">{$slot.window|escape:'html':'UTF-8'}</span>
+                </div>
+                {if isset($slot.inquiry_url) && $slot.inquiry_url}
+                  <a class="btn btn-primary btn-sm" href="{$slot.inquiry_url|escape:'html':'UTF-8'}">{l s='Plan this stay' d='Shop.Theme.Kunstort'}</a>
+                {/if}
               </li>
             {/foreach}
           </ul>

--- a/themes/hotel-reservation-theme/storytelling/gastronomy.tpl
+++ b/themes/hotel-reservation-theme/storytelling/gastronomy.tpl
@@ -55,9 +55,14 @@
         {if isset($storytelling.availability.slots) && $storytelling.availability.slots}
           <ul class="list-unstyled kl-storytelling__availability-slots">
             {foreach from=$storytelling.availability.slots item=slot}
-              <li>
-                <strong>{$slot.label|escape:'html':'UTF-8'}</strong>
-                <span class="text-muted">{$slot.window|escape:'html':'UTF-8'}</span>
+              <li class="kl-storytelling__availability-slot">
+                <div class="kl-storytelling__availability-slot-meta">
+                  <strong>{$slot.label|escape:'html':'UTF-8'}</strong>
+                  <span class="text-muted">{$slot.window|escape:'html':'UTF-8'}</span>
+                </div>
+                {if isset($slot.inquiry_url) && $slot.inquiry_url}
+                  <a class="btn btn-primary btn-sm" href="{$slot.inquiry_url|escape:'html':'UTF-8'}">{l s='Plan this stay' d='Shop.Theme.Kunstort'}</a>
+                {/if}
               </li>
             {/foreach}
           </ul>

--- a/themes/hotel-reservation-theme/storytelling/programme.tpl
+++ b/themes/hotel-reservation-theme/storytelling/programme.tpl
@@ -76,10 +76,15 @@
                   {/if}
                 </header>
                 {if $group.slot}
-                  <p>
-                    <strong>{l s='Next opening:' d='Shop.Theme.Kunstort'}</strong>
-                    <span class="text-muted">{$group.slot.window|escape:'html':'UTF-8'}</span>
-                  </p>
+                  <div class="kl-storytelling__availability-slot">
+                    <div class="kl-storytelling__availability-slot-meta">
+                      <strong>{l s='Next opening:' d='Shop.Theme.Kunstort'}</strong>
+                      <span class="text-muted">{$group.slot.window|escape:'html':'UTF-8'}</span>
+                    </div>
+                    {if isset($group.slot.inquiry_url) && $group.slot.inquiry_url}
+                      <a class="btn btn-primary btn-sm" href="{$group.slot.inquiry_url|escape:'html':'UTF-8'}">{l s='Plan this stay' d='Shop.Theme.Kunstort'}</a>
+                    {/if}
+                  </div>
                 {else}
                   <p class="text-muted">{l s='We are still mapping live availability for this space type.' d='Shop.Theme.Kunstort'}</p>
                 {/if}
@@ -89,9 +94,14 @@
         {elseif isset($storytelling.availability.slots) && $storytelling.availability.slots}
           <ul class="list-unstyled kl-storytelling__availability-slots">
             {foreach from=$storytelling.availability.slots item=slot}
-              <li>
-                <strong>{$slot.label|escape:'html':'UTF-8'}</strong>
-                <span class="text-muted">{$slot.window|escape:'html':'UTF-8'}</span>
+              <li class="kl-storytelling__availability-slot">
+                <div class="kl-storytelling__availability-slot-meta">
+                  <strong>{$slot.label|escape:'html':'UTF-8'}</strong>
+                  <span class="text-muted">{$slot.window|escape:'html':'UTF-8'}</span>
+                </div>
+                {if isset($slot.inquiry_url) && $slot.inquiry_url}
+                  <a class="btn btn-primary btn-sm" href="{$slot.inquiry_url|escape:'html':'UTF-8'}">{l s='Plan this stay' d='Shop.Theme.Kunstort'}</a>
+                {/if}
               </li>
             {/foreach}
           </ul>

--- a/themes/hotel-reservation-theme/storytelling/residencies.tpl
+++ b/themes/hotel-reservation-theme/storytelling/residencies.tpl
@@ -55,9 +55,14 @@
         {if isset($storytelling.availability.slots) && $storytelling.availability.slots}
           <ul class="list-unstyled kl-storytelling__availability-slots">
             {foreach from=$storytelling.availability.slots item=slot}
-              <li>
-                <strong>{$slot.label|escape:'html':'UTF-8'}</strong>
-                <span class="text-muted">{$slot.window|escape:'html':'UTF-8'}</span>
+              <li class="kl-storytelling__availability-slot">
+                <div class="kl-storytelling__availability-slot-meta">
+                  <strong>{$slot.label|escape:'html':'UTF-8'}</strong>
+                  <span class="text-muted">{$slot.window|escape:'html':'UTF-8'}</span>
+                </div>
+                {if isset($slot.inquiry_url) && $slot.inquiry_url}
+                  <a class="btn btn-primary btn-sm" href="{$slot.inquiry_url|escape:'html':'UTF-8'}">{l s='Plan this stay' d='Shop.Theme.Kunstort'}</a>
+                {/if}
               </li>
             {/foreach}
           </ul>


### PR DESCRIPTION
## Summary
- extend the storytelling presenter to attach per-slot inquiry parameters and URLs while preserving existing tracking
- render CTA buttons next to availability slots across residencies, ateliers, gastronomy and programme templates with responsive styling updates
- prefill the inquiry form from new query parameters and document the CTA enhancement in task tracking and project guides

## Testing
- php -l modules/hotelreservationsystem/classes/HotelReservationSystemStorytellingPresenter.php
- php -l controllers/front/InquiryController.php

------
https://chatgpt.com/codex/tasks/task_e_68e306e0a6dc8321a04cb84310de8767