### PR TITLE
Add storytelling pricing highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Key characteristics of the fork:
 - 🏷️ **Amenity catalogue manager** – a new Catalog → Amenities screen lets staff create reusable amenity codes, toggle availability and capture icon/translation metadata in preparation for resource-level linking.
 - 🧮 **Room-type seeding helper** – install/upgrade flows and `modules/hotelreservationsystem/tools/seed_resource_profiles.php` backfill taxonomy profiles and capacities for existing room types so legacy data is represented immediately.
 - 🧶 **Storytelling scaffolding** – feature-flagged residencies (`index.php?controller=residencies`), ateliers (`index.php?controller=ateliers`), gastronomy (`index.php?controller=gastronomy`) and programme (`index.php?controller=programme`) landings now pull taxonomy-driven sections, scope-aware featured package groups, grouped availability snapshots, amenity callouts, slot-level inquiry CTAs and CMS-managed hero/highlight/practical/FAQ/testimonial slots when `_KUNSTORT_STORYTELLING_LAUNCH_` is enabled.
+- 💡 **Storytelling pricing highlights** – featured packages now display cached starting rates, sample stay context and inclusion summaries generated via canonical calls to `KLQuotePricingEngine::generateQuote()`.
 - 🖼️ **Hero media pipeline** – taxonomy stories expose hero media references and alt text; the theme ships `npm run build:hero-media` to emit responsive WebP/JPEG variants while storytelling templates render lazy-loaded `<picture>` elements with accessible captions.
 - 💼 **Rate plan & quote engine** – the module now ships database tables and `ObjectModel` classes for rate plans, seasonal modifiers, bundled packages and inquiry-linked quotes, and the `KLQuotePricingEngine` turns those definitions into inquiry-ready pricing breakdowns.
 - 🗓️ **Rate plan console** – manage plan metadata, eligibility scopes and seasonal adjustments directly from the back office.
@@ -59,6 +60,8 @@ or output `<template data-kl-storytelling-defer data-src="/modules/feature.js" d
 Availability snapshots surface CTA buttons beside each slot; the presenter now emits slot-specific inquiry URLs so clicking a CTA opens the inquiry form with arrival/departure fields, resource kind and the highlighted resource code already filled in.
 
 Featured packages render as grouped cards keyed to each resource kind scope, complete with CTA buttons that deep-link into the inquiry form with package codes and resource interests preselected. Packages without scope metadata fall back to a campus-wide highlight group so cross-cutting bundles stay visible.
+
+Pricing highlights reuse those package groups: the presenter now assembles canonical sample stays per package, calls `KLQuotePricingEngine::generateQuote()` and caches the resulting starting rate, sample stay description and inclusion summary so cards show rate guidance without hammering the engine.
 
 - **Residencies CMS keys:** `KL_STORY_RESIDENCIES_HERO`, `KL_STORY_RESIDENCIES_AVAILABILITY`, `KL_STORY_RESIDENCIES_PRACTICAL`, `KL_STORY_RESIDENCIES_FAQ`, `KL_STORY_RESIDENCIES_TESTIMONIALS`.
 - **Ateliers CMS keys:** `KL_STORY_ATELIERS_HERO`, `KL_STORY_ATELIERS_AVAILABILITY`, `KL_STORY_ATELIERS_PRACTICAL`, `KL_STORY_ATELIERS_FAQ`, `KL_STORY_ATELIERS_TESTIMONIALS`.

--- a/checklist.md
+++ b/checklist.md
@@ -53,6 +53,7 @@
   - [x] Pipe taxonomy hero media into responsive `<picture>` components with lazy loading, captions and WebP/JPEG variants generated via `npm run build:hero-media`.
   - [x] Wire slot-specific inquiry CTAs so availability windows launch the inquiry form with matching resource codes and dates prefilled.
   - [x] Group featured packages by resource scope, add inquiry CTA buttons per card and provide a campus-wide fallback for unscoped bundles.
+  - [x] Surface pricing highlights on storytelling package cards by caching canonical quotes from `KLQuotePricingEngine`.
   - [ ] Port shared components to ateliers/studios, gastronomy and programme templates.
   - [ ] Wire CMS content keys, testimonial feed and FAQ data sources.
   - [ ] Add Lighthouse/Panther regression tests for performance and accessibility budgets.

--- a/concept.md
+++ b/concept.md
@@ -39,6 +39,7 @@ Create a lean, fully self-hosted hospitality operations tool tailored to Kunstor
 - The residencies landing availability snapshot now queries live bookings and maintenance blocks, surfaces the earliest openings per resource kind and caches the summary for 15 minutes so visitors see timely inquiry prompts without hammering the booking tables.
 - Availability slots across residencies, ateliers, gastronomy and programme storytelling landings now display per-slot inquiry CTAs that deep-link into the inquiry form with arrival/departure dates, resource kind and resource codes prefilled.
 - Featured packages on storytelling landings are grouped by scope with CTA buttons that prefill package codes and resource interests on the inquiry form, with a campus-wide fallback for bundles that lack scope metadata.
+- Storytelling package cards now display cached pricing highlights—starting rates, sample stay context and inclusion summaries—powered by canonical sample stays passed to `KLQuotePricingEngine::generateQuote()`.
 - Legacy PrestaShop webservice entry points are stubbed; `/webservice` responds with HTTP 410 and no admin UI exposes API keys.
 - A repo-level `start_dev.sh` script provisions a Python virtualenv for tooling, keeps Composer dependencies current, and boots the PHP built-in server for local testing.
 

--- a/devtasks/storytelling-pricing-highlights.task.md
+++ b/devtasks/storytelling-pricing-highlights.task.md
@@ -1,0 +1,31 @@
+# Task Brief: Storytelling Pricing Highlights
+
+## Objective
+Surface rate guidance on storytelling package cards by querying the pricing engine with canonical sample stays, then expose the resulting starting rate and inclusions alongside existing CTA copy.
+
+## Key Deliverables
+- Presenter helpers that assemble canonical sample stay requests per featured package and call `KLQuotePricingEngine::generateQuote()` to retrieve pricing summaries.
+- Package DTO updates that cache highlight payloads per language/shop so heavy pricing requests are reused during the request lifecycle.
+- Storytelling templates (residencies, ateliers, gastronomy, programme) updated to render starting-rate headlines, sample stay context and inclusion summaries with graceful fallbacks when pricing is unavailable.
+- A lightweight CSS block to style the highlight panel within existing storytelling cards.
+
+## Technical Considerations
+- Canonical stay logic should consider package duration metadata and linked rate plans when picking the sample check-in/check-out window; fall back to sensible defaults if data is missing.
+- Cache highlight payloads via the presenter (and PrestaShop's cache layer) with an expiry so repeated page loads do not spam the pricing engine.
+- Handle missing rate plans, unpublished resource profiles or quote errors gracefully—front-end output should default to "coming soon" messaging instead of surfacing exceptions.
+- Reuse translation helpers so highlight strings are localisation-ready and match the storytelling domain namespace.
+
+## Dependencies & Coordination
+- Coordinate with the pricing team to validate the canonical stay definitions per package type.
+- Confirm with editorial that inclusion labels align with component terminology already used in inquiry communications.
+
+## Acceptance Criteria
+- Featured packages on all storytelling landings display a starting rate headline, sample stay description and inclusion summary when rate plan/package data is complete.
+- Packages missing prerequisite data display a translated fallback message instead of leaving empty space.
+- Highlight data is cached per package/lang/shop combination and expires automatically to avoid stale pricing.
+- Documentation (`concept.md`, `checklist.md`, `README.md`, `roadmap.md`) reflects the new storytelling pricing highlights capability.
+
+## QA Notes
+- Smoke-test each storytelling landing with `_KUNSTORT_STORYTELLING_LAUNCH_` enabled to verify highlight rendering, currency formatting and fallback messaging.
+- Temporarily disable a package's linked rate plan to confirm the templates show the fallback message instead of crashing.
+- Monitor logs for pricing-engine exceptions while browsing the storytelling pages to ensure caching prevents repeated failures.

--- a/devtasks/tasks.md
+++ b/devtasks/tasks.md
@@ -14,5 +14,6 @@ This folder tracks near-term development efforts for the Kunstort Lehnin fork. E
 | [Storytelling hero media](storytelling-hero-media.task.md) | 🚧 In progress | Stand up the hero media pipeline, responsive `<picture>` markup and asset tooling for storytelling templates. |
 | [Storytelling availability CTAs](storytelling-availability-cta.task.md) | 🚧 In progress | Surface inquiry buttons on availability slots and prefill the inquiry form from slot metadata. |
 | [Storytelling package CTAs](storytelling-package-ctas.task.md) | 🚧 In progress | Group featured packages by scope and surface inquiry buttons on storytelling landings. |
+| [Storytelling pricing highlights](storytelling-pricing-highlights.task.md) | 🚧 In progress | Expose canonical starting rates and inclusions on storytelling package cards. |
 
 Update this table whenever task briefs change status or new tasks are added.

--- a/modules/hotelreservationsystem/classes/HotelReservationSystemStorytellingPresenter.php
+++ b/modules/hotelreservationsystem/classes/HotelReservationSystemStorytellingPresenter.php
@@ -21,6 +21,8 @@ class HotelReservationSystemStorytellingPresenter
 {
     const AVAILABILITY_CACHE_TTL = 900;
 
+    const PACKAGE_HIGHLIGHT_CACHE_TTL = 1800;
+
     const CMS_SLOT_KEYS = array(
         'residencies' => array(
             'hero' => 'KL_STORY_RESIDENCIES_HERO',
@@ -71,6 +73,11 @@ class HotelReservationSystemStorytellingPresenter
      * @var array<string, array<int, array<string, mixed>>> cache of published profiles per lang/shop
      */
     private $profileCache = array();
+
+    /**
+     * @var array<string, array<string, mixed>> cache of package highlight payloads per lang/shop/package
+     */
+    private $packageHighlightCache = array();
 
     /**
      * @var array<int, int> cache of active room counts per product id
@@ -764,8 +771,18 @@ class HotelReservationSystemStorytellingPresenter
      */
     protected function getPublishedProfiles($idLang, $idShop)
     {
+        $idLang = (int) $idLang;
+        $idShop = (int) $idShop;
+
+        $cacheKey = $idLang.'-'.$idShop;
+        if (isset($this->profileCache[$cacheKey])) {
+            return $this->profileCache[$cacheKey];
+        }
+
         $profiles = KLResourceProfile::getPublishedProfilesWithDetails($idLang, $idShop);
         if (!$profiles) {
+            $this->profileCache[$cacheKey] = array();
+
             return array();
         }
 
@@ -791,6 +808,8 @@ class HotelReservationSystemStorytellingPresenter
             }
             unset($profile);
         }
+
+        $this->profileCache[$cacheKey] = $profiles;
 
         return $profiles;
     }
@@ -1291,6 +1310,7 @@ class HotelReservationSystemStorytellingPresenter
     {
         $query = new DbQuery();
         $query->select('p.`id_kl_package`, p.`package_code`, p.`resource_kind_scope`');
+        $query->select('p.`id_kl_rate_plan`, p.`duration_mode`, p.`duration_value`');
         $query->select('pl.`name`, pl.`tagline`, pl.`description`');
         $query->from('kl_package', 'p');
         $query->innerJoin('kl_package_lang', 'pl', 'p.`id_kl_package` = pl.`id_kl_package` AND pl.`id_lang` = '.(int) $idLang);
@@ -1312,6 +1332,9 @@ class HotelReservationSystemStorytellingPresenter
                 'tagline' => $row['tagline'],
                 'description' => $row['description'],
                 'resource_kind_scope' => $this->decodeJsonArray($row['resource_kind_scope']),
+                'id_kl_rate_plan' => isset($row['id_kl_rate_plan']) ? (int) $row['id_kl_rate_plan'] : 0,
+                'duration_mode' => isset($row['duration_mode']) ? $row['duration_mode'] : null,
+                'duration_value' => isset($row['duration_value']) ? (int) $row['duration_value'] : null,
             );
         }
 
@@ -1441,7 +1464,9 @@ class HotelReservationSystemStorytellingPresenter
                     $package,
                     $scope,
                     $baseParameters,
-                    $link
+                    $link,
+                    $idLang,
+                    $idShop
                 );
             }
         }
@@ -1469,10 +1494,12 @@ class HotelReservationSystemStorytellingPresenter
      * @param string|null $scope
      * @param array<string, string> $baseParameters
      * @param Link|null $link
+     * @param int $idLang
+     * @param int $idShop
      *
      * @return array<string, mixed>
      */
-    protected function buildPackageEntryForStorytelling(array $package, $scope, array $baseParameters, $link)
+    protected function buildPackageEntryForStorytelling(array $package, $scope, array $baseParameters, $link, $idLang, $idShop)
     {
         $translator = $this->getTranslator();
 
@@ -1512,7 +1539,509 @@ class HotelReservationSystemStorytellingPresenter
             ? $translator->trans('Request this package', array(), 'Shop.Theme.Kunstort')
             : 'Request this package';
 
+        $entry['highlight'] = $this->resolvePackageHighlight($package, $idLang, $idShop);
+
         return $entry;
+    }
+
+    /**
+     * @param array<string, mixed> $package
+     * @param int $idLang
+     * @param int $idShop
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolvePackageHighlight(array $package, $idLang, $idShop)
+    {
+        $translator = $this->getTranslator();
+
+        $message = $translator
+            ? $translator->trans('Pricing preview coming soon.', array(), 'Shop.Theme.Kunstort')
+            : 'Pricing preview coming soon.';
+
+        $baseHighlight = array(
+            'status' => 'pending',
+            'message' => $message,
+            'warnings' => array(),
+            'generated_at' => date(DATE_ATOM),
+        );
+
+        $idPackage = isset($package['id_kl_package']) ? (int) $package['id_kl_package'] : 0;
+        if ($idPackage <= 0) {
+            return $baseHighlight;
+        }
+
+        $cacheKey = $this->getPackageHighlightCacheKey($idLang, $idShop, $idPackage);
+        if ($cacheKey !== '' && isset($this->packageHighlightCache[$cacheKey])) {
+            return $this->packageHighlightCache[$cacheKey];
+        }
+
+        if ($cacheKey !== '') {
+            $cached = $this->retrievePackageHighlightCache($cacheKey);
+            if ($cached !== null) {
+                $this->packageHighlightCache[$cacheKey] = $cached;
+
+                return $cached;
+            }
+        }
+
+        $highlight = $this->buildPackageHighlightPayload($package, $idLang, $idShop, $baseHighlight);
+
+        if ($cacheKey !== '') {
+            $this->packageHighlightCache[$cacheKey] = $highlight;
+            $this->storePackageHighlightCache($cacheKey, $highlight);
+        }
+
+        return $highlight;
+    }
+
+    /**
+     * @param array<string, mixed> $package
+     * @param int $idLang
+     * @param int $idShop
+     * @param array<string, mixed> $fallback
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildPackageHighlightPayload(array $package, $idLang, $idShop, array $fallback)
+    {
+        $translator = $this->getTranslator();
+
+        $idRatePlan = isset($package['id_kl_rate_plan']) ? (int) $package['id_kl_rate_plan'] : 0;
+        if ($idRatePlan <= 0) {
+            return $fallback;
+        }
+
+        $plan = new KLRatePlan($idRatePlan, $idLang);
+        if (!Validate::isLoadedObject($plan) || !$plan->is_active) {
+            return $fallback;
+        }
+
+        $idProfile = $this->findHighlightResourceProfileId($package, $plan, $idLang, $idShop);
+        if ($idProfile <= 0) {
+            $fallback['message'] = $translator
+                ? $translator->trans('Pricing preview activates once sample resources are published.', array(), 'Shop.Theme.Kunstort')
+                : 'Pricing preview activates once sample resources are published.';
+
+            return $fallback;
+        }
+
+        $stay = $this->buildCanonicalStayWindow($package, $plan);
+
+        try {
+            $quote = KLQuotePricingEngine::generateQuote(array(
+                'id_kl_rate_plan' => (int) $plan->id,
+                'id_kl_package' => isset($package['id_kl_package']) ? (int) $package['id_kl_package'] : 0,
+                'id_kl_resource_profile' => $idProfile,
+                'check_in' => $stay['check_in'],
+                'check_out' => $stay['check_out'],
+                'id_lang' => (int) $idLang,
+            ));
+        } catch (Exception $exception) {
+            $fallback['status'] = 'error';
+            $fallback['message'] = $translator
+                ? $translator->trans('Pricing preview is temporarily unavailable.', array(), 'Shop.Theme.Kunstort')
+                : 'Pricing preview is temporarily unavailable.';
+
+            return $fallback;
+        }
+
+        $price = $this->formatMinorCurrency(
+            isset($quote['gross_total_minor']) ? (int) $quote['gross_total_minor'] : 0,
+            isset($quote['currency_iso_code']) ? (string) $quote['currency_iso_code'] : '',
+            $idShop
+        );
+
+        $headline = $translator
+            ? $translator->trans('Starting from %price%', array('%price%' => $price['formatted']), 'Shop.Theme.Kunstort')
+            : 'Starting from '.$price['formatted'];
+
+        $nights = isset($quote['nights']) ? (int) $quote['nights'] : 0;
+        if ($nights <= 0) {
+            $nights = isset($stay['nights']) ? (int) $stay['nights'] : 1;
+        }
+        if ($nights <= 0) {
+            $nights = 1;
+        }
+
+        $planLabel = '';
+        if (isset($quote['plan']) && is_array($quote['plan'])) {
+            if (!empty($quote['plan']['name'])) {
+                $planLabel = (string) $quote['plan']['name'];
+            } elseif (!empty($quote['plan']['plan_code'])) {
+                $planLabel = (string) $quote['plan']['plan_code'];
+            }
+        }
+        $planLabel = trim($planLabel);
+
+        if ($planLabel !== '') {
+            $sampleLabel = $translator
+                ? $translator->trans(
+                    'Sample stay: %nights%-night stay on the %plan% plan.',
+                    array(
+                        '%nights%' => $nights,
+                        '%plan%' => $planLabel,
+                    ),
+                    'Shop.Theme.Kunstort'
+                )
+                : sprintf('Sample stay: %d-night stay on the %s plan.', $nights, $planLabel);
+        } else {
+            $sampleLabel = $translator
+                ? $translator->trans(
+                    'Sample stay: %nights%-night stay.',
+                    array('%nights%' => $nights),
+                    'Shop.Theme.Kunstort'
+                )
+                : sprintf('Sample stay: %d-night stay.', $nights);
+        }
+
+        $inclusions = $this->summariseHighlightInclusions($quote);
+        $inclusionsLabel = '';
+        if (!empty($inclusions)) {
+            $inclusionsLabel = $translator
+                ? $translator->trans(
+                    'Includes: %list%',
+                    array('%list%' => implode(', ', $inclusions)),
+                    'Shop.Theme.Kunstort'
+                )
+                : 'Includes: '.implode(', ', $inclusions);
+        }
+
+        $warningLabel = '';
+        if (!empty($quote['warnings'])) {
+            $warningLabel = $translator
+                ? $translator->trans('Additional conditions apply—our team will confirm the final quote.', array(), 'Shop.Theme.Kunstort')
+                : 'Additional conditions apply—our team will confirm the final quote.';
+        }
+
+        return array(
+            'status' => 'ready',
+            'message' => '',
+            'headline' => $headline,
+            'price' => $price,
+            'sample_label' => $sampleLabel,
+            'inclusions' => $inclusions,
+            'inclusions_label' => $inclusionsLabel,
+            'warning_label' => $warningLabel,
+            'warnings' => isset($quote['warnings']) && is_array($quote['warnings']) ? $quote['warnings'] : array(),
+            'generated_at' => date(DATE_ATOM),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $package
+     * @param KLRatePlan $plan
+     * @param int $idLang
+     * @param int $idShop
+     *
+     * @return int
+     */
+    protected function findHighlightResourceProfileId(array $package, KLRatePlan $plan, $idLang, $idShop)
+    {
+        $profiles = $this->getPublishedProfiles($idLang, $idShop);
+        if (empty($profiles)) {
+            return 0;
+        }
+
+        $scopes = array();
+        if (!empty($package['resource_kind_scope']) && is_array($package['resource_kind_scope'])) {
+            foreach ($package['resource_kind_scope'] as $scope) {
+                $scope = trim((string) $scope);
+                if ($scope !== '') {
+                    $scopes[] = $scope;
+                }
+            }
+        }
+
+        if (!$scopes) {
+            $planScopes = $plan->getResourceKindScope();
+            if (!empty($planScopes)) {
+                foreach ($planScopes as $scope) {
+                    $scope = trim((string) $scope);
+                    if ($scope !== '') {
+                        $scopes[] = $scope;
+                    }
+                }
+            }
+        }
+
+        if (!$scopes) {
+            $scopes = KLResourceProfile::getSupportedResourceKinds();
+        }
+
+        foreach ($scopes as $scope) {
+            $idProfile = $this->pickProfileForHighlight($profiles, (string) $scope);
+            if ($idProfile > 0) {
+                return $idProfile;
+            }
+        }
+
+        return $this->pickProfileForHighlight($profiles, null);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $profiles
+     * @param string|null $resourceKind
+     *
+     * @return int
+     */
+    protected function pickProfileForHighlight(array $profiles, $resourceKind)
+    {
+        foreach ($profiles as $profile) {
+            $profileKind = isset($profile['resource_kind']) ? (string) $profile['resource_kind'] : '';
+            if ($resourceKind !== null && $profileKind !== (string) $resourceKind) {
+                continue;
+            }
+            if (empty($profile['is_bookable'])) {
+                continue;
+            }
+            if (empty($profile['id_kl_resource_profile'])) {
+                continue;
+            }
+            if (empty($profile['id_product'])) {
+                continue;
+            }
+
+            return (int) $profile['id_kl_resource_profile'];
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param array<string, mixed> $package
+     * @param KLRatePlan $plan
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildCanonicalStayWindow(array $package, KLRatePlan $plan)
+    {
+        $durationMode = isset($package['duration_mode']) ? (string) $package['duration_mode'] : '';
+        $durationValue = isset($package['duration_value']) ? (int) $package['duration_value'] : 0;
+
+        $nights = $this->resolveCanonicalNights($durationMode, $durationValue, $plan);
+
+        try {
+            $start = new DateTimeImmutable('first day of next month');
+        } catch (Exception $exception) {
+            $start = new DateTimeImmutable('now');
+        }
+
+        $checkIn = $start->format('Y-m-d');
+        $checkOut = $start->add(new DateInterval('P'.$nights.'D'))->format('Y-m-d');
+
+        return array(
+            'check_in' => $checkIn,
+            'check_out' => $checkOut,
+            'nights' => $nights,
+        );
+    }
+
+    /**
+     * @param string $durationMode
+     * @param int $durationValue
+     * @param KLRatePlan $plan
+     *
+     * @return int
+     */
+    protected function resolveCanonicalNights($durationMode, $durationValue, KLRatePlan $plan)
+    {
+        $value = (int) $durationValue;
+
+        switch ($durationMode) {
+            case 'nights':
+                $nights = max(1, $value);
+                break;
+            case 'days':
+                $nights = max(1, $value > 0 ? $value - 1 : 0);
+                break;
+            case 'weeks':
+                $nights = max(1, $value * 7);
+                break;
+            default:
+                if ($plan->pricing_method === 'weekly') {
+                    $nights = 7;
+                } elseif ($plan->pricing_method === 'nightly') {
+                    $nights = max(1, $value);
+                } else {
+                    $nights = max(1, $value);
+                }
+        }
+
+        return $nights;
+    }
+
+    /**
+     * @param array<string, mixed> $quote
+     *
+     * @return array<int, string>
+     */
+    protected function summariseHighlightInclusions(array $quote)
+    {
+        if (empty($quote['component_applications']) || !is_array($quote['component_applications'])) {
+            return array();
+        }
+
+        $labels = $this->getComponentTypeLabels();
+        $inclusions = array();
+
+        foreach ($quote['component_applications'] as $component) {
+            if (!is_array($component)) {
+                continue;
+            }
+
+            $isOptional = !empty($component['is_optional']);
+            $selected = isset($component['selected']) ? (bool) $component['selected'] : true;
+            if ($isOptional && !$selected) {
+                continue;
+            }
+
+            $type = '';
+            if (isset($component['metadata']) && is_array($component['metadata']) && !empty($component['metadata']['component_type'])) {
+                $type = Tools::strtolower((string) $component['metadata']['component_type']);
+            } elseif (!empty($component['label'])) {
+                $type = Tools::strtolower((string) $component['label']);
+            }
+
+            $label = '';
+            if ($type !== '' && isset($labels[$type])) {
+                $label = $labels[$type];
+            } elseif ($type !== '') {
+                $label = Tools::ucfirst(str_replace('_', ' ', $type));
+            }
+
+            if ($label === '' && !empty($component['label'])) {
+                $label = (string) $component['label'];
+            }
+
+            $label = trim($label);
+            if ($label === '') {
+                continue;
+            }
+
+            $inclusions[$label] = true;
+        }
+
+        return array_keys($inclusions);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function getComponentTypeLabels()
+    {
+        $translator = $this->getTranslator();
+
+        return array(
+            'lodging' => $translator
+                ? $translator->trans('Residency lodging', array(), 'Shop.Theme.Kunstort')
+                : 'Residency lodging',
+            'atelier' => $translator
+                ? $translator->trans('Atelier or studio session', array(), 'Shop.Theme.Kunstort')
+                : 'Atelier or studio session',
+            'meal' => $translator
+                ? $translator->trans('Meal or catering service', array(), 'Shop.Theme.Kunstort')
+                : 'Meal or catering service',
+            'experience' => $translator
+                ? $translator->trans('Experience or excursion', array(), 'Shop.Theme.Kunstort')
+                : 'Experience or excursion',
+            'custom' => $translator
+                ? $translator->trans('Custom component', array(), 'Shop.Theme.Kunstort')
+                : 'Custom component',
+        );
+    }
+
+    /**
+     * @param int $amountMinor
+     * @param string $currencyIso
+     * @param int $idShop
+     *
+     * @return array<string, mixed>
+     */
+    protected function formatMinorCurrency($amountMinor, $currencyIso, $idShop)
+    {
+        $amountMinor = (int) $amountMinor;
+        $currencyIso = (string) $currencyIso;
+        $idShop = (int) $idShop;
+
+        $idCurrency = 0;
+        if ($currencyIso !== '') {
+            $idCurrency = (int) Currency::getIdByIsoCode($currencyIso, $idShop > 0 ? $idShop : null);
+            if (!$idCurrency) {
+                $idCurrency = (int) Currency::getIdByIsoCode($currencyIso);
+            }
+        }
+
+        if (!$idCurrency) {
+            $idCurrency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        }
+
+        $currency = Currency::getCurrencyInstance($idCurrency);
+        $amount = $amountMinor / 100;
+
+        return array(
+            'amount_minor' => $amountMinor,
+            'amount' => $amount,
+            'currency_iso_code' => $currency ? (string) $currency->iso_code : $currencyIso,
+            'formatted' => Tools::displayPrice($amount, $currency),
+        );
+    }
+
+    /**
+     * @param int $idLang
+     * @param int $idShop
+     * @param int $idPackage
+     *
+     * @return string
+     */
+    protected function getPackageHighlightCacheKey($idLang, $idShop, $idPackage)
+    {
+        $idPackage = (int) $idPackage;
+        if ($idPackage <= 0) {
+            return '';
+        }
+
+        return 'KL_STORY_PACKAGE_HIGHLIGHT_'.(int) $idLang.'_'.(int) $idShop.'_'.$idPackage;
+    }
+
+    /**
+     * @param string $cacheKey
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function retrievePackageHighlightCache($cacheKey)
+    {
+        if ($cacheKey === '' || !Cache::isStored($cacheKey)) {
+            return null;
+        }
+
+        $cached = Cache::retrieve($cacheKey);
+        if (!is_array($cached) || !isset($cached['expires_at']) || !isset($cached['payload'])) {
+            return null;
+        }
+        if ($cached['expires_at'] < time()) {
+            return null;
+        }
+
+        return is_array($cached['payload']) ? $cached['payload'] : null;
+    }
+
+    /**
+     * @param string $cacheKey
+     * @param array<string, mixed> $payload
+     *
+     * @return void
+     */
+    protected function storePackageHighlightCache($cacheKey, array $payload)
+    {
+        if ($cacheKey === '') {
+            return;
+        }
+
+        Cache::store($cacheKey, array(
+            'expires_at' => time() + self::PACKAGE_HIGHLIGHT_CACHE_TTL,
+            'payload' => $payload,
+        ));
     }
 
     /**

--- a/roadmap.md
+++ b/roadmap.md
@@ -29,6 +29,7 @@ This roadmap tracks how the Kunstort Lehnin fork evolves from a de-bloated QloAp
   - ✅ Storytelling hero media pipeline generates WebP/JPEG variants via `npm run build:hero-media`, exposes taxonomy alt text in the presenter payload and renders lazy-loaded `<picture>` components with accessible captions across all storytelling templates.
   - ✅ Storytelling availability slots now surface CTA buttons wired to slot-specific inquiry URLs so arrival/departure dates, resource kind and resource codes prefill the inquiry flow.
   - ✅ Featured packages now display as scope-aware groups with inquiry CTA buttons and a campus-wide fallback when scope metadata is missing.
+  - ✅ Storytelling package cards now surface cached pricing highlights generated from canonical sample stays via `KLQuotePricingEngine::generateQuote()`.
 
 ## Phase 3 – Operations Automation (🚧 In progress)
 - ✅ **Housekeeping automation** – the `kloperations` module now generates arrival/checkout housekeeping tasks via cron, syncs booking lifecycle statuses and exposes an Operations → Tasks console. Architectural notes live in [`docs/blueprints/operations-automation.md`](docs/blueprints/operations-automation.md) with implementation details tracked in [`devtasks/operations-automation.task.md`](devtasks/operations-automation.task.md).

--- a/themes/hotel-reservation-theme/css/storytelling.css
+++ b/themes/hotel-reservation-theme/css/storytelling.css
@@ -290,6 +290,29 @@
 .kl-storytelling__package h4 {
   margin-bottom: 0.5rem;
 }
+.kl-storytelling__package-highlight {
+  background-color: rgba(44, 123, 229, 0.06);
+  border-radius: 0.75rem;
+  margin: 0.75rem 0;
+  padding: 0.75rem 1rem;
+}
+.kl-storytelling__package-price {
+  color: var(--kl-storytelling-accent-dark);
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+.kl-storytelling__package-sample,
+.kl-storytelling__package-inclusions {
+  margin-bottom: 0.35rem;
+}
+.kl-storytelling__package-warning {
+  color: #b45309;
+  font-size: 0.9375rem;
+  margin-bottom: 0;
+}
+.kl-storytelling__package-message {
+  margin: 0.5rem 0 0;
+}
 .kl-storytelling__package-actions {
   margin-top: clamp(0.75rem, 2vw, 1.25rem);
 }

--- a/themes/hotel-reservation-theme/storytelling/ateliers.tpl
+++ b/themes/hotel-reservation-theme/storytelling/ateliers.tpl
@@ -131,6 +131,24 @@
                     {if $package.tagline}
                       <p class="text-muted">{$package.tagline|escape:'html':'UTF-8'}</p>
                     {/if}
+                    {if isset($package.highlight)}
+                      {if $package.highlight.status == 'ready'}
+                        <div class="kl-storytelling__package-highlight">
+                          <p class="kl-storytelling__package-price h5">{$package.highlight.headline|escape:'html':'UTF-8'}</p>
+                          {if $package.highlight.sample_label}
+                            <p class="text-muted kl-storytelling__package-sample">{$package.highlight.sample_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                          {if $package.highlight.inclusions_label}
+                            <p class="text-muted kl-storytelling__package-inclusions">{$package.highlight.inclusions_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                          {if $package.highlight.warning_label}
+                            <p class="kl-storytelling__package-warning">{$package.highlight.warning_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                        </div>
+                      {elseif $package.highlight.message}
+                        <p class="text-muted kl-storytelling__package-message">{$package.highlight.message|escape:'html':'UTF-8'}</p>
+                      {/if}
+                    {/if}
                     {if $package.description}
                       <div class="kl-storytelling__package-description text-muted">
                         {$package.description nofilter}

--- a/themes/hotel-reservation-theme/storytelling/gastronomy.tpl
+++ b/themes/hotel-reservation-theme/storytelling/gastronomy.tpl
@@ -138,6 +138,24 @@
                     {if $package.tagline}
                       <p class="text-muted">{$package.tagline|escape:'html':'UTF-8'}</p>
                     {/if}
+                    {if isset($package.highlight)}
+                      {if $package.highlight.status == 'ready'}
+                        <div class="kl-storytelling__package-highlight">
+                          <p class="kl-storytelling__package-price h5">{$package.highlight.headline|escape:'html':'UTF-8'}</p>
+                          {if $package.highlight.sample_label}
+                            <p class="text-muted kl-storytelling__package-sample">{$package.highlight.sample_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                          {if $package.highlight.inclusions_label}
+                            <p class="text-muted kl-storytelling__package-inclusions">{$package.highlight.inclusions_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                          {if $package.highlight.warning_label}
+                            <p class="kl-storytelling__package-warning">{$package.highlight.warning_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                        </div>
+                      {elseif $package.highlight.message}
+                        <p class="text-muted kl-storytelling__package-message">{$package.highlight.message|escape:'html':'UTF-8'}</p>
+                      {/if}
+                    {/if}
                     {if $package.description}
                       <div class="kl-storytelling__package-description text-muted">
                         {$package.description nofilter}

--- a/themes/hotel-reservation-theme/storytelling/programme.tpl
+++ b/themes/hotel-reservation-theme/storytelling/programme.tpl
@@ -192,6 +192,24 @@
                     {if $package.tagline}
                       <p class="text-muted">{$package.tagline|escape:'html':'UTF-8'}</p>
                     {/if}
+                    {if isset($package.highlight)}
+                      {if $package.highlight.status == 'ready'}
+                        <div class="kl-storytelling__package-highlight">
+                          <p class="kl-storytelling__package-price h5">{$package.highlight.headline|escape:'html':'UTF-8'}</p>
+                          {if $package.highlight.sample_label}
+                            <p class="text-muted kl-storytelling__package-sample">{$package.highlight.sample_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                          {if $package.highlight.inclusions_label}
+                            <p class="text-muted kl-storytelling__package-inclusions">{$package.highlight.inclusions_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                          {if $package.highlight.warning_label}
+                            <p class="kl-storytelling__package-warning">{$package.highlight.warning_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                        </div>
+                      {elseif $package.highlight.message}
+                        <p class="text-muted kl-storytelling__package-message">{$package.highlight.message|escape:'html':'UTF-8'}</p>
+                      {/if}
+                    {/if}
                     {if $package.description}
                       <div class="kl-storytelling__package-description text-muted">
                         {$package.description nofilter}

--- a/themes/hotel-reservation-theme/storytelling/residencies.tpl
+++ b/themes/hotel-reservation-theme/storytelling/residencies.tpl
@@ -131,6 +131,24 @@
                     {if $package.tagline}
                       <p class="text-muted">{$package.tagline|escape:'html':'UTF-8'}</p>
                     {/if}
+                    {if isset($package.highlight)}
+                      {if $package.highlight.status == 'ready'}
+                        <div class="kl-storytelling__package-highlight">
+                          <p class="kl-storytelling__package-price h5">{$package.highlight.headline|escape:'html':'UTF-8'}</p>
+                          {if $package.highlight.sample_label}
+                            <p class="text-muted kl-storytelling__package-sample">{$package.highlight.sample_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                          {if $package.highlight.inclusions_label}
+                            <p class="text-muted kl-storytelling__package-inclusions">{$package.highlight.inclusions_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                          {if $package.highlight.warning_label}
+                            <p class="kl-storytelling__package-warning">{$package.highlight.warning_label|escape:'html':'UTF-8'}</p>
+                          {/if}
+                        </div>
+                      {elseif $package.highlight.message}
+                        <p class="text-muted kl-storytelling__package-message">{$package.highlight.message|escape:'html':'UTF-8'}</p>
+                      {/if}
+                    {/if}
                     {if $package.description}
                       <div class="kl-storytelling__package-description text-muted">
                         {$package.description nofilter}


### PR DESCRIPTION
## Summary
- call `KLQuotePricingEngine::generateQuote()` from the storytelling presenter using cached canonical sample stays per package
- extend package DTOs, Smarty templates, and CSS to render pricing highlights with fallback messaging across all storytelling landings
- document the new pricing-highlight task and update concept, checklist, README, and roadmap to reflect the capability

## Testing
- php -l modules/hotelreservationsystem/classes/HotelReservationSystemStorytellingPresenter.php


------
https://chatgpt.com/codex/tasks/task_e_68e311df1e9c8321a57dcd1de299c0bc